### PR TITLE
feat: Windows tray app, Inno Setup installer, and release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,205 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # ── Docker image (amd64 + arm64) ───────────────────────────────────────────
+  docker:
+    name: Docker image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/deluno
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=semver,pattern={{version}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  # ── Windows installer (tags only) ──────────────────────────────────────────
+  windows:
+    name: Windows installer
+    runs-on: windows-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Extract version
+        id: version
+        shell: pwsh
+        run: |
+          $tag = "${{ github.ref_name }}"
+          $version = $tag.TrimStart('v')
+          echo "version=$version" >> $env:GITHUB_OUTPUT
+          echo "tag=$tag" >> $env:GITHUB_OUTPUT
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Build frontend
+        run: npm run build:web
+
+      - name: Publish Deluno.Tray (win-x64)
+        shell: pwsh
+        run: |
+          dotnet publish apps/windows-tray/Deluno.Tray.csproj `
+            -c Release `
+            -r win-x64 `
+            --self-contained true `
+            -p:PublishSingleFile=false `
+            -p:Version=${{ steps.version.outputs.version }} `
+            -o artifacts/windows/bin
+
+      - name: Install Inno Setup
+        run: choco install innosetup --no-progress -y
+
+      - name: Compile installer
+        shell: pwsh
+        run: |
+          $iscc = "C:\Program Files (x86)\Inno Setup 6\ISCC.exe"
+          & $iscc installer/deluno-setup.iss `
+            /DAppVersion=${{ steps.version.outputs.version }} `
+            /DBinDir=..\..\artifacts\windows\bin
+        working-directory: ${{ github.workspace }}
+
+      - name: Compute SHA256
+        id: checksum
+        shell: pwsh
+        run: |
+          $hash = (Get-FileHash "artifacts/windows/installer/Deluno-Setup-${{ steps.version.outputs.version }}.exe" -Algorithm SHA256).Hash.ToLower()
+          echo "sha256=$hash" >> $env:GITHUB_OUTPUT
+
+      - name: Write checksum file
+        shell: pwsh
+        run: |
+          $version = "${{ steps.version.outputs.version }}"
+          "${{ steps.checksum.outputs.sha256 }}  Deluno-Setup-$version.exe" | `
+            Out-File -FilePath "artifacts/windows/installer/Deluno-Setup-$version.exe.sha256" -Encoding utf8
+
+      - name: Upload installer artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-installer
+          path: |
+            artifacts/windows/installer/Deluno-Setup-*.exe
+            artifacts/windows/installer/Deluno-Setup-*.exe.sha256
+          retention-days: 7
+
+  # ── GitHub Release (tags only) ─────────────────────────────────────────────
+  release:
+    name: GitHub Release
+    runs-on: ubuntu-latest
+    needs: [docker, windows]
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract version
+        id: version
+        run: |
+          TAG="${{ github.ref_name }}"
+          echo "version=${TAG#v}" >> $GITHUB_OUTPUT
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+
+      - name: Download installer artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: windows-installer
+          path: release-assets
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: Deluno ${{ steps.version.outputs.tag }}
+          draft: false
+          prerelease: ${{ contains(steps.version.outputs.tag, '-') }}
+          body: |
+            ## Deluno ${{ steps.version.outputs.tag }}
+
+            ### Installation
+
+            **Windows** — Download and run the installer below. Requires Windows 10 or later.
+
+            **Docker**
+            ```bash
+            docker pull ghcr.io/${{ github.repository_owner }}/deluno:${{ steps.version.outputs.tag }}
+            ```
+
+            Or with Docker Compose — see [`compose.yaml`](https://github.com/${{ github.repository }}/blob/main/compose.yaml) in the repository.
+
+            ### Verify Windows installer integrity
+
+            ```powershell
+            $expected = (Get-Content "Deluno-Setup-${{ steps.version.outputs.version }}.exe.sha256").Split(' ')[0]
+            $actual   = (Get-FileHash "Deluno-Setup-${{ steps.version.outputs.version }}.exe" -Algorithm SHA256).Hash.ToLower()
+            if ($expected -eq $actual) { "✓ Checksum verified" } else { "✗ Checksum mismatch — do not run" }
+            ```
+
+            ### What's changed
+
+            See [commit history](https://github.com/${{ github.repository }}/commits/${{ steps.version.outputs.tag }}) for full details.
+          files: |
+            release-assets/Deluno-Setup-*.exe
+            release-assets/Deluno-Setup-*.exe.sha256

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,13 +32,17 @@ This file is the small entry point for agent work. It is a map, not the full man
 
 ## Validation
 
-Use the smallest relevant checks while working, then run the broader gates before committing substantial changes:
+Run the smallest relevant checks while working. Before every push, run the CI gate:
 
-```powershell
-.\.dotnet\dotnet.exe test .\Deluno.slnx --configuration Release
-npm.cmd run build:web
-npm.cmd run test:web
-npm.cmd run validate:agents
+```bash
+bash scripts/ci-check.sh        # backend build + frontend build + agent readiness
+```
+
+Before merging, also run the full test suite:
+
+```bash
+dotnet test Deluno.slnx --configuration Release
+npm run test:web
 ```
 
 ## Mechanical Guardrails

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,36 @@
+# Deluno — Claude Code
+
+## Pre-push gate (mandatory)
+
+Run this before every `git push`. No exceptions.
+
+```bash
+bash scripts/ci-check.sh
+```
+
+It restores + builds the backend (Release), builds the frontend, and validates the
+agent-readiness map. Takes ~60 s. Catches the same errors GitHub Actions catches.
+**Do not push unless this script exits 0.**
+
+## Windows tray project
+
+`apps/windows-tray/` targets `net10.0-windows`. A MSBuild condition excludes all source
+files on non-Windows so the Linux CI build succeeds. This means:
+
+- Solution-wide `dotnet build` on Linux silently skips tray source — it will not catch tray errors.
+- Always validate tray changes separately before pushing:
+  ```bash
+  dotnet build apps/windows-tray/Deluno.Tray.csproj
+  ```
+  (run this on Windows where the project actually compiles)
+
+## Branch strategy
+
+- Active development branches off `main`.
+- PR target is always `main`.
+- The `feature/windows-packaging` branch contains the Windows tray app and installer.
+
+## Key docs
+
+Full guidance lives in `AGENTS.md` and the `docs/` tree. This file covers only the
+rules specific to working with Claude Code.

--- a/Deluno.slnx
+++ b/Deluno.slnx
@@ -1,4 +1,7 @@
 <Solution>
+  <Folder Name="/apps/">
+    <Project Path="apps/windows-tray/Deluno.Tray.csproj" />
+  </Folder>
   <Folder Name="/src/">
     <Project Path="src/Deluno.Api/Deluno.Api.csproj" />
     <Project Path="src/Deluno.Contracts/Deluno.Contracts.csproj" />

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -3,8 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="theme-color" content="#6366f1" media="(prefers-color-scheme: dark)" />
-    <meta name="theme-color" content="#4f46e5" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#F5A623" media="(prefers-color-scheme: dark)" />
+    <meta name="theme-color" content="#F5A623" media="(prefers-color-scheme: light)" />
     <meta name="description" content="Deluno — The premier self-hosted media automation platform. Movies, TV, indexers, and download clients in one place." />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/apps/web/public/favicon.svg
+++ b/apps/web/public/favicon.svg
@@ -1,23 +1,27 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0%" stop-color="#FFD060"/>
       <stop offset="100%" stop-color="#F5A028"/>
     </linearGradient>
   </defs>
-  <rect width="32" height="32" rx="7" fill="url(#bg)"/>
 
-  <!-- Film frame screen outline -->
-  <rect x="5.5" y="10" width="21" height="12" rx="2.5" stroke="white" stroke-width="1.8" fill="none"/>
+  <!-- Background: 100×100, rx≈22% matching iOS squircle -->
+  <rect width="100" height="100" rx="22" fill="url(#bg)"/>
 
-  <!-- Film strip tabs — left edge (two tabs straddling the left stroke) -->
-  <rect x="3.5" y="12"   width="4" height="2.5" rx="0.6" fill="white"/>
-  <rect x="3.5" y="17.5" width="4" height="2.5" rx="0.6" fill="white"/>
+  <!-- Screen outline: 70% wide × 50% tall, centred -->
+  <!-- x=15 y=25 w=70 h=50 → left=15 right=85 top=25 bottom=75 -->
+  <rect x="15" y="25" width="70" height="50" rx="7" stroke="white" stroke-width="5.5" fill="none"/>
 
-  <!-- Film strip tabs — right edge -->
-  <rect x="24.5" y="12"   width="4" height="2.5" rx="0.6" fill="white"/>
-  <rect x="24.5" y="17.5" width="4" height="2.5" rx="0.6" fill="white"/>
+  <!-- Film strip tabs — left edge (straddle x=15, two tabs in upper/lower thirds) -->
+  <rect x="9"  y="36" width="12" height="9" rx="2" fill="white"/>
+  <rect x="9"  y="55" width="12" height="9" rx="2" fill="white"/>
 
-  <!-- Play triangle, centred in the screen -->
-  <polygon points="13.5,12.5 13.5,19.5 21,16" fill="white"/>
+  <!-- Film strip tabs — right edge (straddle x=85) -->
+  <rect x="79" y="36" width="12" height="9" rx="2" fill="white"/>
+  <rect x="79" y="55" width="12" height="9" rx="2" fill="white"/>
+
+  <!-- Play triangle — visually centred at (50,50), ~40% of screen height -->
+  <!-- height=20, width=18; visual mid-x=(41+59)/2=50, visual mid-y=(40+60)/2=50 -->
+  <polygon points="41,40 41,60 59,50" fill="white"/>
 </svg>

--- a/apps/web/public/favicon.svg
+++ b/apps/web/public/favicon.svg
@@ -1,13 +1,13 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#FFCA6B"/>
-      <stop offset="100%" stop-color="#F5881F"/>
+      <stop offset="0%" stop-color="#FFC84A"/>
+      <stop offset="100%" stop-color="#F07820"/>
     </linearGradient>
   </defs>
   <rect width="32" height="32" rx="7" fill="url(#bg)"/>
   <!-- Screen outline -->
-  <rect x="5.5" y="8" width="21" height="16" rx="2.5" stroke="white" stroke-width="1.8" fill="none"/>
-  <!-- Play triangle -->
-  <polygon points="13.5,12.5 13.5,19.5 21,16" fill="white"/>
+  <rect x="5" y="8" width="22" height="16" rx="3" stroke="white" stroke-width="2.2" fill="none"/>
+  <!-- Play triangle, centred in screen -->
+  <polygon points="13,12 13,20 21.5,16" fill="white"/>
 </svg>

--- a/apps/web/public/favicon.svg
+++ b/apps/web/public/favicon.svg
@@ -1,13 +1,23 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#FFC84A"/>
-      <stop offset="100%" stop-color="#F07820"/>
+      <stop offset="0%" stop-color="#FFD060"/>
+      <stop offset="100%" stop-color="#F5A028"/>
     </linearGradient>
   </defs>
   <rect width="32" height="32" rx="7" fill="url(#bg)"/>
-  <!-- Screen outline -->
-  <rect x="5" y="8" width="22" height="16" rx="3" stroke="white" stroke-width="2.2" fill="none"/>
-  <!-- Play triangle, centred in screen -->
-  <polygon points="13,12 13,20 21.5,16" fill="white"/>
+
+  <!-- Film frame screen outline -->
+  <rect x="5.5" y="10" width="21" height="12" rx="2.5" stroke="white" stroke-width="1.8" fill="none"/>
+
+  <!-- Film strip tabs — top edge (two tabs straddling the top stroke) -->
+  <rect x="9"    y="7.5" width="2.5" height="4" rx="0.6" fill="white"/>
+  <rect x="20.5" y="7.5" width="2.5" height="4" rx="0.6" fill="white"/>
+
+  <!-- Film strip tabs — bottom edge -->
+  <rect x="9"    y="20.5" width="2.5" height="4" rx="0.6" fill="white"/>
+  <rect x="20.5" y="20.5" width="2.5" height="4" rx="0.6" fill="white"/>
+
+  <!-- Play triangle, centred in the screen -->
+  <polygon points="13.5,12.5 13.5,19.5 21,16" fill="white"/>
 </svg>

--- a/apps/web/public/favicon.svg
+++ b/apps/web/public/favicon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="7" fill="#6366f1"/>
+  <defs>
+    <mask id="m">
+      <rect width="32" height="32" fill="white"/>
+      <circle cx="22" cy="11" r="10" fill="black"/>
+    </mask>
+  </defs>
+  <circle cx="16" cy="17" r="11" fill="white" mask="url(#m)"/>
+</svg>

--- a/apps/web/public/favicon.svg
+++ b/apps/web/public/favicon.svg
@@ -10,13 +10,13 @@
   <!-- Film frame screen outline -->
   <rect x="5.5" y="10" width="21" height="12" rx="2.5" stroke="white" stroke-width="1.8" fill="none"/>
 
-  <!-- Film strip tabs — top edge (two tabs straddling the top stroke) -->
-  <rect x="9"    y="7.5" width="2.5" height="4" rx="0.6" fill="white"/>
-  <rect x="20.5" y="7.5" width="2.5" height="4" rx="0.6" fill="white"/>
+  <!-- Film strip tabs — left edge (two tabs straddling the left stroke) -->
+  <rect x="3.5" y="12"   width="4" height="2.5" rx="0.6" fill="white"/>
+  <rect x="3.5" y="17.5" width="4" height="2.5" rx="0.6" fill="white"/>
 
-  <!-- Film strip tabs — bottom edge -->
-  <rect x="9"    y="20.5" width="2.5" height="4" rx="0.6" fill="white"/>
-  <rect x="20.5" y="20.5" width="2.5" height="4" rx="0.6" fill="white"/>
+  <!-- Film strip tabs — right edge -->
+  <rect x="24.5" y="12"   width="4" height="2.5" rx="0.6" fill="white"/>
+  <rect x="24.5" y="17.5" width="4" height="2.5" rx="0.6" fill="white"/>
 
   <!-- Play triangle, centred in the screen -->
   <polygon points="13.5,12.5 13.5,19.5 21,16" fill="white"/>

--- a/apps/web/public/favicon.svg
+++ b/apps/web/public/favicon.svg
@@ -1,10 +1,13 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
-  <rect width="32" height="32" rx="7" fill="#6366f1"/>
   <defs>
-    <mask id="m">
-      <rect width="32" height="32" fill="white"/>
-      <circle cx="22" cy="11" r="10" fill="black"/>
-    </mask>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#FFCA6B"/>
+      <stop offset="100%" stop-color="#F5881F"/>
+    </linearGradient>
   </defs>
-  <circle cx="16" cy="17" r="11" fill="white" mask="url(#m)"/>
+  <rect width="32" height="32" rx="7" fill="url(#bg)"/>
+  <!-- Screen outline -->
+  <rect x="5.5" y="8" width="21" height="16" rx="2.5" stroke="white" stroke-width="1.8" fill="none"/>
+  <!-- Play triangle -->
+  <polygon points="13.5,12.5 13.5,19.5 21,16" fill="white"/>
 </svg>

--- a/apps/web/public/manifest.json
+++ b/apps/web/public/manifest.json
@@ -7,7 +7,7 @@
   "display": "standalone",
   "display_override": ["window-controls-overlay", "standalone"],
   "orientation": "any",
-  "theme_color": "#6366f1",
+  "theme_color": "#F5A623",
   "background_color": "#0e0f13",
   "lang": "en",
   "categories": ["utilities", "productivity"],

--- a/apps/web/public/manifest.json
+++ b/apps/web/public/manifest.json
@@ -13,22 +13,10 @@
   "categories": ["utilities", "productivity"],
   "icons": [
     {
-      "src": "/icon-192.png",
-      "sizes": "192x192",
-      "type": "image/png",
+      "src": "/favicon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
       "purpose": "any"
-    },
-    {
-      "src": "/icon-512.png",
-      "sizes": "512x512",
-      "type": "image/png",
-      "purpose": "any"
-    },
-    {
-      "src": "/icon-maskable-512.png",
-      "sizes": "512x512",
-      "type": "image/png",
-      "purpose": "maskable"
     }
   ],
   "shortcuts": [
@@ -37,39 +25,31 @@
       "short_name": "Movies",
       "description": "Browse and manage your movie library",
       "url": "/movies",
-      "icons": [{ "src": "/icon-192.png", "sizes": "192x192" }]
+      "icons": [{ "src": "/favicon.svg", "sizes": "any" }]
     },
     {
       "name": "TV Shows",
       "short_name": "TV",
       "description": "Browse and manage your TV show library",
       "url": "/tv",
-      "icons": [{ "src": "/icon-192.png", "sizes": "192x192" }]
+      "icons": [{ "src": "/favicon.svg", "sizes": "any" }]
     },
     {
       "name": "Activity",
       "short_name": "Activity",
       "description": "View download queue and activity log",
       "url": "/activity",
-      "icons": [{ "src": "/icon-192.png", "sizes": "192x192" }]
+      "icons": [{ "src": "/favicon.svg", "sizes": "any" }]
     },
     {
       "name": "System",
       "short_name": "System",
       "description": "System health and audit timeline",
       "url": "/system",
-      "icons": [{ "src": "/icon-192.png", "sizes": "192x192" }]
+      "icons": [{ "src": "/favicon.svg", "sizes": "any" }]
     }
   ],
-  "screenshots": [
-    {
-      "src": "/screenshot-wide.png",
-      "sizes": "1280x720",
-      "type": "image/png",
-      "form_factor": "wide",
-      "label": "Deluno dashboard overview"
-    }
-  ],
+  "screenshots": [],
   "prefer_related_applications": false,
   "related_applications": []
 }

--- a/apps/web/src/layouts/app-layout.tsx
+++ b/apps/web/src/layouts/app-layout.tsx
@@ -625,12 +625,12 @@ function AppMark({ size = 30 }: { size?: number }) {
     >
       <rect width="30" height="30" rx="7.5" fill="url(#mark-bg)" />
       <rect x="0.75" y="0.75" width="28.5" height="14" rx="6.75" fill="white" fillOpacity="0.08" />
-      <rect x="5.5" y="9" width="19" height="12" rx="2.5" stroke="white" strokeWidth="1.3" strokeOpacity="0.7" />
-      <rect x="5.5" y="11.25" width="2.5" height="2.25" rx="0.5" fill="white" fillOpacity="0.6" />
-      <rect x="5.5" y="16.5" width="2.5" height="2.25" rx="0.5" fill="white" fillOpacity="0.6" />
-      <rect x="22" y="11.25" width="2.5" height="2.25" rx="0.5" fill="white" fillOpacity="0.6" />
-      <rect x="22" y="16.5" width="2.5" height="2.25" rx="0.5" fill="white" fillOpacity="0.6" />
-      <path d="M13.75 12.75L19 15L13.75 17.25V12.75Z" fill="white" fillOpacity="0.95" />
+      <rect x="4.5" y="7.5" width="21" height="15" rx="2.1" stroke="white" strokeWidth="1.5" fill="none" />
+      <rect x="2.7" y="10.8" width="3.6" height="2.7" rx="0.6" fill="white" />
+      <rect x="2.7" y="16.5" width="3.6" height="2.7" rx="0.6" fill="white" />
+      <rect x="23.7" y="10.8" width="3.6" height="2.7" rx="0.6" fill="white" />
+      <rect x="23.7" y="16.5" width="3.6" height="2.7" rx="0.6" fill="white" />
+      <polygon points="12.3,12 12.3,18 17.7,15" fill="white" />
       <defs>
         <linearGradient id="mark-bg" x1="0" y1="0" x2="30" y2="30" gradientUnits="userSpaceOnUse">
           <stop style={{ stopColor: "hsl(var(--primary))" }} />

--- a/apps/web/src/routes/login-page.tsx
+++ b/apps/web/src/routes/login-page.tsx
@@ -64,12 +64,12 @@ export function LoginPage() {
             }}
           >
             <svg width="28" height="28" viewBox="0 0 30 30" fill="none" aria-hidden>
-              <rect x="5.5" y="9" width="19" height="12" rx="2.5" stroke="white" strokeWidth="1.3" strokeOpacity="0.9" />
-              <rect x="5.5" y="11.25" width="2.5" height="2.25" rx="0.5" fill="white" fillOpacity="0.7" />
-              <rect x="5.5" y="16.5" width="2.5" height="2.25" rx="0.5" fill="white" fillOpacity="0.7" />
-              <rect x="22" y="11.25" width="2.5" height="2.25" rx="0.5" fill="white" fillOpacity="0.7" />
-              <rect x="22" y="16.5" width="2.5" height="2.25" rx="0.5" fill="white" fillOpacity="0.7" />
-              <path d="M13.75 12.75L19 15L13.75 17.25V12.75Z" fill="white" fillOpacity="0.95" />
+              <rect x="4.5" y="7.5" width="21" height="15" rx="2.1" stroke="white" strokeWidth="1.5" fill="none" />
+              <rect x="2.7" y="10.8" width="3.6" height="2.7" rx="0.6" fill="white" />
+              <rect x="2.7" y="16.5" width="3.6" height="2.7" rx="0.6" fill="white" />
+              <rect x="23.7" y="10.8" width="3.6" height="2.7" rx="0.6" fill="white" />
+              <rect x="23.7" y="16.5" width="3.6" height="2.7" rx="0.6" fill="white" />
+              <polygon points="12.3,12 12.3,18 17.7,15" fill="white" />
             </svg>
           </div>
           <div className="text-center">

--- a/apps/web/src/routes/setup-page.tsx
+++ b/apps/web/src/routes/setup-page.tsx
@@ -68,12 +68,12 @@ export function SetupPage() {
             }}
           >
             <svg width="28" height="28" viewBox="0 0 30 30" fill="none" aria-hidden>
-              <rect x="5.5" y="9" width="19" height="12" rx="2.5" stroke="white" strokeWidth="1.3" strokeOpacity="0.9" />
-              <rect x="5.5" y="11.25" width="2.5" height="2.25" rx="0.5" fill="white" fillOpacity="0.7" />
-              <rect x="5.5" y="16.5" width="2.5" height="2.25" rx="0.5" fill="white" fillOpacity="0.7" />
-              <rect x="22" y="11.25" width="2.5" height="2.25" rx="0.5" fill="white" fillOpacity="0.7" />
-              <rect x="22" y="16.5" width="2.5" height="2.25" rx="0.5" fill="white" fillOpacity="0.7" />
-              <path d="M13.75 12.75L19 15L13.75 17.25V12.75Z" fill="white" fillOpacity="0.95" />
+              <rect x="4.5" y="7.5" width="21" height="15" rx="2.1" stroke="white" strokeWidth="1.5" fill="none" />
+              <rect x="2.7" y="10.8" width="3.6" height="2.7" rx="0.6" fill="white" />
+              <rect x="2.7" y="16.5" width="3.6" height="2.7" rx="0.6" fill="white" />
+              <rect x="23.7" y="10.8" width="3.6" height="2.7" rx="0.6" fill="white" />
+              <rect x="23.7" y="16.5" width="3.6" height="2.7" rx="0.6" fill="white" />
+              <polygon points="12.3,12 12.3,18 17.7,15" fill="white" />
             </svg>
           </div>
           <div className="text-center">

--- a/apps/windows-tray/AppSettings.cs
+++ b/apps/windows-tray/AppSettings.cs
@@ -1,0 +1,45 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Deluno.Tray;
+
+public sealed class AppSettings
+{
+    private static readonly string _configPath = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
+        "Deluno", "data", "deluno.json");
+
+    public int Port { get; set; } = 7879;
+    public string DataRoot { get; set; } = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
+        "Deluno", "data");
+
+    public static AppSettings Load()
+    {
+        if (!File.Exists(_configPath))
+            return new AppSettings();
+
+        try
+        {
+            var json = File.ReadAllText(_configPath);
+            return JsonSerializer.Deserialize<AppSettings>(json, JsonOptions) ?? new AppSettings();
+        }
+        catch
+        {
+            return new AppSettings();
+        }
+    }
+
+    public void Save()
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(_configPath)!);
+        File.WriteAllText(_configPath, JsonSerializer.Serialize(this, JsonOptions));
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+}

--- a/apps/windows-tray/Deluno.Tray.csproj
+++ b/apps/windows-tray/Deluno.Tray.csproj
@@ -16,6 +16,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.0" />
   </ItemGroup>
 

--- a/apps/windows-tray/Deluno.Tray.csproj
+++ b/apps/windows-tray/Deluno.Tray.csproj
@@ -32,6 +32,11 @@
     <ProjectReference Include="..\..\src\Deluno.Worker\Deluno.Worker.csproj" />
   </ItemGroup>
 
+  <!-- On non-Windows CI, skip compilation — restore is enough for dependency checks -->
+  <ItemGroup Condition="!$([MSBuild]::IsOSPlatform('Windows'))">
+    <Compile Remove="**/*.cs" />
+  </ItemGroup>
+
   <!-- Bundle the compiled web frontend if it has been built -->
   <ItemGroup Condition="Exists('..\..\apps\web\dist')">
     <Content Include="..\..\apps\web\dist\**\*">

--- a/apps/windows-tray/Deluno.Tray.csproj
+++ b/apps/windows-tray/Deluno.Tray.csproj
@@ -9,6 +9,8 @@
     <AssemblyName>Deluno</AssemblyName>
     <Platforms>x64</Platforms>
     <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
+    <!-- Allows dotnet restore/build on Linux CI for the windows-targeted project -->
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <!-- Version injected at publish time via /p:Version -->
     <Version>0.1.0</Version>
   </PropertyGroup>

--- a/apps/windows-tray/Deluno.Tray.csproj
+++ b/apps/windows-tray/Deluno.Tray.csproj
@@ -16,10 +16,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.0" />
   </ItemGroup>
 

--- a/apps/windows-tray/Deluno.Tray.csproj
+++ b/apps/windows-tray/Deluno.Tray.csproj
@@ -32,7 +32,11 @@
     <ProjectReference Include="..\..\src\Deluno.Worker\Deluno.Worker.csproj" />
   </ItemGroup>
 
-  <!-- On non-Windows CI, skip compilation — restore is enough for dependency checks -->
+  <!-- On non-Windows CI, build as an empty library — restore validates dependencies,
+       WinExe OutputType would require an entry point even with no source files. -->
+  <PropertyGroup Condition="!$([MSBuild]::IsOSPlatform('Windows'))">
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
   <ItemGroup Condition="!$([MSBuild]::IsOSPlatform('Windows'))">
     <Compile Remove="**/*.cs" />
   </ItemGroup>

--- a/apps/windows-tray/Deluno.Tray.csproj
+++ b/apps/windows-tray/Deluno.Tray.csproj
@@ -1,0 +1,41 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <OutputType>WinExe</OutputType>
+    <UseWindowsForms>true</UseWindowsForms>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>Deluno.Tray</RootNamespace>
+    <AssemblyName>Deluno</AssemblyName>
+    <Platforms>x64</Platforms>
+    <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
+    <!-- Version injected at publish time via /p:Version -->
+    <Version>0.1.0</Version>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Deluno.Api\Deluno.Api.csproj" />
+    <ProjectReference Include="..\..\src\Deluno.Filesystem\Deluno.Filesystem.csproj" />
+    <ProjectReference Include="..\..\src\Deluno.Infrastructure\Deluno.Infrastructure.csproj" />
+    <ProjectReference Include="..\..\src\Deluno.Integrations\Deluno.Integrations.csproj" />
+    <ProjectReference Include="..\..\src\Deluno.Jobs\Deluno.Jobs.csproj" />
+    <ProjectReference Include="..\..\src\Deluno.Movies\Deluno.Movies.csproj" />
+    <ProjectReference Include="..\..\src\Deluno.Platform\Deluno.Platform.csproj" />
+    <ProjectReference Include="..\..\src\Deluno.Realtime\Deluno.Realtime.csproj" />
+    <ProjectReference Include="..\..\src\Deluno.Series\Deluno.Series.csproj" />
+    <ProjectReference Include="..\..\src\Deluno.Worker\Deluno.Worker.csproj" />
+  </ItemGroup>
+
+  <!-- Bundle the compiled web frontend if it has been built -->
+  <ItemGroup Condition="Exists('..\..\apps\web\dist')">
+    <Content Include="..\..\apps\web\dist\**\*">
+      <Link>wwwroot\%(RecursiveDir)%(Filename)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+  </ItemGroup>
+</Project>

--- a/apps/windows-tray/DelunoServer.cs
+++ b/apps/windows-tray/DelunoServer.cs
@@ -1,0 +1,199 @@
+using Deluno.Api;
+using Deluno.Api.Backup;
+using Deluno.Filesystem;
+using Deluno.Infrastructure;
+using Deluno.Integrations.DownloadClients;
+using Deluno.Integrations.Metadata;
+using Deluno.Integrations.Search;
+using Deluno.Jobs;
+using Deluno.Movies;
+using Deluno.Platform;
+using Deluno.Realtime;
+using Deluno.Series;
+using Deluno.Worker;
+using Microsoft.AspNetCore.DataProtection;
+using UserAuthorization = Deluno.Platform.UserAuthorization;
+
+namespace Deluno.Tray;
+
+public sealed class DelunoServer : IDisposable
+{
+    private WebApplication? _app;
+    private CancellationTokenSource? _cts;
+
+    public async Task StartAsync()
+    {
+        _cts = new CancellationTokenSource();
+        var settings = AppSettings.Load();
+
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+        {
+            WebRootPath = Path.Combine(AppContext.BaseDirectory, "wwwroot")
+        });
+
+        builder.WebHost.ConfigureKestrel(opts => opts.ListenAnyIP(settings.Port));
+
+        // Override config values with resolved Windows paths
+        builder.Configuration["Storage:DataRoot"] = settings.DataRoot;
+        builder.Configuration["Kestrel:EndPoints:Http:Url"] = $"http://+:{settings.Port}";
+
+        builder.Services.AddDelunoInfrastructure(builder.Configuration);
+        builder.Services.AddDelunoApi();
+        builder.Services.AddDelunoPlatformModule();
+        builder.Services.AddDelunoMoviesModule();
+        builder.Services.AddDelunoSeriesModule();
+        builder.Services.AddDelunoJobsModule();
+        builder.Services.AddDelunoIntegrationsModule();
+        builder.Services.AddDelunoFilesystemModule();
+        builder.Services.AddDelunoRealtimeModule();
+        builder.Services.AddDelunoWorkerModule();
+        builder.Services.AddHostedService<ImportRecoveryCleanupService>();
+
+        builder.Services
+            .AddDataProtection()
+            .SetApplicationName("Deluno")
+            .PersistKeysToFileSystem(new DirectoryInfo(Path.Combine(settings.DataRoot, "protection-keys")));
+
+        _app = builder.Build();
+
+        _app.UseExceptionHandler(errorApp =>
+        {
+            errorApp.Run(async context =>
+            {
+                context.Response.StatusCode = 500;
+                context.Response.ContentType = "application/json";
+                await context.Response.WriteAsync("{\"error\":\"An unexpected error occurred.\"}");
+            });
+        });
+
+        _app.Use(async (context, next) =>
+        {
+            context.Response.Headers["X-Content-Type-Options"] = "nosniff";
+            context.Response.Headers["X-Frame-Options"] = "DENY";
+            context.Response.Headers["X-XSS-Protection"] = "1; mode=block";
+            context.Response.Headers["Referrer-Policy"] = "strict-origin-when-cross-origin";
+            await next();
+        });
+
+        _app.UseDefaultFiles();
+        _app.UseStaticFiles();
+        _app.UseDelunoCorrelation();
+
+        _app.Use(async (context, next) =>
+        {
+            var path = context.Request.Path;
+            if (path.StartsWithSegments("/api", StringComparison.OrdinalIgnoreCase) ||
+                path.StartsWithSegments("/hubs", StringComparison.OrdinalIgnoreCase))
+            {
+                context.Response.Headers.CacheControl = "no-store";
+            }
+            await next();
+        });
+
+        _app.Use(async (context, next) =>
+        {
+            var path = context.Request.Path;
+            var requiresAuth =
+                (path.StartsWithSegments("/api", StringComparison.OrdinalIgnoreCase) &&
+                 !path.Equals("/api/auth/login", StringComparison.OrdinalIgnoreCase) &&
+                 !path.Equals("/api/auth/bootstrap-status", StringComparison.OrdinalIgnoreCase) &&
+                 !path.Equals("/api/auth/bootstrap", StringComparison.OrdinalIgnoreCase) &&
+                 !path.StartsWithSegments("/api/health", StringComparison.OrdinalIgnoreCase)) ||
+                path.StartsWithSegments("/hubs", StringComparison.OrdinalIgnoreCase);
+
+            if (!requiresAuth) { await next(); return; }
+
+            var repo = context.RequestServices.GetRequiredService<Deluno.Platform.Data.IPlatformSettingsRepository>();
+            var denied = await UserAuthorization.RequireAuthenticatedAsync(context, repo, context.RequestAborted);
+            if (denied is not null) { await denied.ExecuteAsync(context); return; }
+
+            var scopeDenied = UserAuthorization.RequireApiScope(context, ResolveScopes(path, context.Request.Method));
+            if (scopeDenied is not null) { await scopeDenied.ExecuteAsync(context); return; }
+
+            await next();
+        });
+
+        _app.MapDelunoApi();
+        _app.MapDelunoBackupEndpoints();
+        _app.MapDelunoPlatformEndpoints();
+        _app.MapDelunoMoviesEndpoints();
+        _app.MapDelunoSeriesEndpoints();
+        _app.MapDelunoJobsEndpoints();
+        _app.MapDelunoDownloadClientIntegrationEndpoints();
+        _app.MapDelunoSearchEndpoints();
+        _app.MapDelunoMetadataEndpoints();
+        _app.MapDelunoFilesystemEndpoints();
+        _app.MapDelunoRealtime();
+        _app.MapFallbackToFile("index.html");
+
+        await _app.StartAsync(_cts.Token);
+    }
+
+    public async Task StopAsync()
+    {
+        if (_app is null) return;
+        await _cts!.CancelAsync();
+        await _app.StopAsync();
+        _app = null;
+    }
+
+    public void Dispose()
+    {
+        _cts?.Dispose();
+        _app?.DisposeAsync().AsTask().GetAwaiter().GetResult();
+    }
+
+    private static string[] ResolveScopes(PathString path, string method)
+    {
+        var isRead = HttpMethods.IsGet(method) || HttpMethods.IsHead(method) || HttpMethods.IsOptions(method);
+        if (isRead) return ["read"];
+        if (path.StartsWithSegments("/api/download-clients", StringComparison.OrdinalIgnoreCase) ||
+            path.StartsWithSegments("/api/download-dispatches", StringComparison.OrdinalIgnoreCase))
+            return ["queue"];
+        if (path.StartsWithSegments("/api/filesystem/import", StringComparison.OrdinalIgnoreCase) ||
+            path.StartsWithSegments("/api/integrations", StringComparison.OrdinalIgnoreCase))
+            return ["imports", "queue"];
+        if (path.StartsWithSegments("/api/backups", StringComparison.OrdinalIgnoreCase))
+            return ["system"];
+        return ["write"];
+    }
+}
+
+// Mirrors the service in Deluno.Host — needed here since Tray doesn't reference Host.
+// This is an intentional duplication; the correct long-term fix is to move this
+// service into Deluno.Worker.
+internal sealed class ImportRecoveryCleanupService(
+    Deluno.Movies.Data.IMovieCatalogRepository movieRepository,
+    Deluno.Series.Data.ISeriesCatalogRepository seriesRepository,
+    TimeProvider timeProvider,
+    ILogger<ImportRecoveryCleanupService> logger)
+    : BackgroundService
+{
+    private static readonly TimeSpan RetentionPeriod = TimeSpan.FromDays(30);
+    private static readonly TimeSpan CleanupInterval = TimeSpan.FromHours(24);
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        using var timer = new PeriodicTimer(CleanupInterval);
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                var cutoff     = timeProvider.GetUtcNow() - RetentionPeriod;
+                var movieCount  = await movieRepository.CleanupImportRecoveryCasesAsync(cutoff, stoppingToken);
+                var seriesCount = await seriesRepository.CleanupImportRecoveryCasesAsync(cutoff, stoppingToken);
+                if (movieCount > 0 || seriesCount > 0)
+                    logger.LogInformation(
+                        "Import recovery cleanup: {M} movie and {S} series cases removed.",
+                        movieCount, seriesCount);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                logger.LogWarning(ex, "Import recovery cleanup error.");
+            }
+
+            try { await timer.WaitForNextTickAsync(stoppingToken); }
+            catch (OperationCanceledException) { break; }
+        }
+    }
+}

--- a/apps/windows-tray/GlobalUsings.cs
+++ b/apps/windows-tray/GlobalUsings.cs
@@ -1,0 +1,4 @@
+global using Microsoft.AspNetCore.Builder;
+global using Microsoft.AspNetCore.Http;
+global using Microsoft.Extensions.Hosting;
+global using Microsoft.Extensions.Logging;

--- a/apps/windows-tray/NativeMethods.cs
+++ b/apps/windows-tray/NativeMethods.cs
@@ -1,0 +1,15 @@
+using System.Runtime.InteropServices;
+
+namespace Deluno.Tray;
+
+internal static partial class NativeMethods
+{
+    internal const int WM_DELUNO_SHOW = 0x8001;
+
+    [LibraryImport("user32.dll", StringMarshalling = StringMarshalling.Utf16)]
+    internal static partial nint FindWindow(string? lpClassName, string? lpWindowName);
+
+    [LibraryImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    internal static partial bool PostMessage(nint hWnd, int msg, nint wParam, nint lParam);
+}

--- a/apps/windows-tray/NativeMethods.cs
+++ b/apps/windows-tray/NativeMethods.cs
@@ -2,14 +2,14 @@ using System.Runtime.InteropServices;
 
 namespace Deluno.Tray;
 
-internal static partial class NativeMethods
+internal static class NativeMethods
 {
     internal const int WM_DELUNO_SHOW = 0x8001;
 
-    [LibraryImport("user32.dll", StringMarshalling = StringMarshalling.Utf16)]
-    internal static partial nint FindWindow(string? lpClassName, string? lpWindowName);
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    internal static extern nint FindWindow(string? lpClassName, string? lpWindowName);
 
-    [LibraryImport("user32.dll")]
+    [DllImport("user32.dll")]
     [return: MarshalAs(UnmanagedType.Bool)]
-    internal static partial bool PostMessage(nint hWnd, int msg, nint wParam, nint lParam);
+    internal static extern bool PostMessage(nint hWnd, int msg, nint wParam, nint lParam);
 }

--- a/apps/windows-tray/Program.cs
+++ b/apps/windows-tray/Program.cs
@@ -1,0 +1,39 @@
+using Deluno.Tray;
+
+// ── Service mode ───────────────────────────────────────────────────────────
+// When Windows SCM starts us as a service, run the ASP.NET host with
+// WindowsServiceLifetime — no WinForms involved.
+if (args.Contains("--service", StringComparer.OrdinalIgnoreCase))
+{
+    await ServiceHost.RunAsync(args);
+    return;
+}
+
+// ── Service management ─────────────────────────────────────────────────────
+if (args.Contains("--install-service", StringComparer.OrdinalIgnoreCase))
+{
+    ServiceManager.Install(args);
+    return;
+}
+
+if (args.Contains("--uninstall-service", StringComparer.OrdinalIgnoreCase))
+{
+    ServiceManager.Uninstall();
+    return;
+}
+
+// ── Tray app mode — enforce single instance ────────────────────────────────
+using var mutex = new Mutex(true, @"Global\DelunoTrayApplication", out bool isFirstInstance);
+if (!isFirstInstance)
+{
+    // Signal the existing instance to open the browser
+    NativeMethods.PostMessage(
+        NativeMethods.FindWindow(null, "Deluno"),
+        NativeMethods.WM_DELUNO_SHOW, IntPtr.Zero, IntPtr.Zero);
+    return;
+}
+
+Application.EnableVisualStyles();
+Application.SetCompatibleTextRenderingDefault(false);
+Application.SetHighDpiMode(HighDpiMode.SystemAware);
+Application.Run(new TrayApplication());

--- a/apps/windows-tray/ServiceHost.cs
+++ b/apps/windows-tray/ServiceHost.cs
@@ -1,0 +1,141 @@
+using Deluno.Api;
+using Deluno.Api.Backup;
+using Deluno.Filesystem;
+using Deluno.Infrastructure;
+using Deluno.Integrations.DownloadClients;
+using Deluno.Integrations.Metadata;
+using Deluno.Integrations.Search;
+using Deluno.Jobs;
+using Deluno.Movies;
+using Deluno.Platform;
+using Deluno.Realtime;
+using Deluno.Series;
+using Deluno.Worker;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.Extensions.Hosting.WindowsServices;
+
+namespace Deluno.Tray;
+
+// Runs when started as a Windows Service (--service flag).
+// Uses WindowsServiceLifetime so the SCM can start/stop/pause the process.
+public static class ServiceHost
+{
+    public static async Task RunAsync(string[] args)
+    {
+        var settings = AppSettings.Load();
+
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+        {
+            Args = args,
+            WebRootPath = Path.Combine(AppContext.BaseDirectory, "wwwroot")
+        });
+
+        builder.Host.UseWindowsService(opts => opts.ServiceName = "Deluno");
+        builder.WebHost.ConfigureKestrel(opts => opts.ListenAnyIP(settings.Port));
+        builder.Configuration["Storage:DataRoot"] = settings.DataRoot;
+
+        builder.Services.AddDelunoInfrastructure(builder.Configuration);
+        builder.Services.AddDelunoApi();
+        builder.Services.AddDelunoPlatformModule();
+        builder.Services.AddDelunoMoviesModule();
+        builder.Services.AddDelunoSeriesModule();
+        builder.Services.AddDelunoJobsModule();
+        builder.Services.AddDelunoIntegrationsModule();
+        builder.Services.AddDelunoFilesystemModule();
+        builder.Services.AddDelunoRealtimeModule();
+        builder.Services.AddDelunoWorkerModule();
+
+        builder.Services
+            .AddDataProtection()
+            .SetApplicationName("Deluno")
+            .PersistKeysToFileSystem(new DirectoryInfo(Path.Combine(settings.DataRoot, "protection-keys")));
+
+        var app = builder.Build();
+
+        app.UseExceptionHandler(errorApp =>
+        {
+            errorApp.Run(async context =>
+            {
+                context.Response.StatusCode = 500;
+                context.Response.ContentType = "application/json";
+                await context.Response.WriteAsync("{\"error\":\"An unexpected error occurred.\"}");
+            });
+        });
+
+        app.Use(async (context, next) =>
+        {
+            context.Response.Headers["X-Content-Type-Options"] = "nosniff";
+            context.Response.Headers["X-Frame-Options"] = "DENY";
+            context.Response.Headers["X-XSS-Protection"] = "1; mode=block";
+            context.Response.Headers["Referrer-Policy"] = "strict-origin-when-cross-origin";
+            context.Response.Headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains";
+            await next();
+        });
+
+        app.UseDefaultFiles();
+        app.UseStaticFiles();
+        app.UseDelunoCorrelation();
+
+        app.Use(async (context, next) =>
+        {
+            var path = context.Request.Path;
+            if (path.StartsWithSegments("/api", StringComparison.OrdinalIgnoreCase) ||
+                path.StartsWithSegments("/hubs", StringComparison.OrdinalIgnoreCase))
+                context.Response.Headers.CacheControl = "no-store";
+            await next();
+        });
+
+        app.Use(async (context, next) =>
+        {
+            var path = context.Request.Path;
+            var requiresAuth =
+                (path.StartsWithSegments("/api", StringComparison.OrdinalIgnoreCase) &&
+                 !path.Equals("/api/auth/login", StringComparison.OrdinalIgnoreCase) &&
+                 !path.Equals("/api/auth/bootstrap-status", StringComparison.OrdinalIgnoreCase) &&
+                 !path.Equals("/api/auth/bootstrap", StringComparison.OrdinalIgnoreCase) &&
+                 !path.StartsWithSegments("/api/health", StringComparison.OrdinalIgnoreCase)) ||
+                path.StartsWithSegments("/hubs", StringComparison.OrdinalIgnoreCase);
+
+            if (!requiresAuth) { await next(); return; }
+
+            var repo = context.RequestServices.GetRequiredService<Deluno.Platform.Data.IPlatformSettingsRepository>();
+            var denied = await UserAuthorization.RequireAuthenticatedAsync(context, repo, context.RequestAborted);
+            if (denied is not null) { await denied.ExecuteAsync(context); return; }
+
+            var scopeDenied = UserAuthorization.RequireApiScope(context, ResolveScopes(path, context.Request.Method));
+            if (scopeDenied is not null) { await scopeDenied.ExecuteAsync(context); return; }
+
+            await next();
+        });
+
+        app.MapDelunoApi();
+        app.MapDelunoBackupEndpoints();
+        app.MapDelunoPlatformEndpoints();
+        app.MapDelunoMoviesEndpoints();
+        app.MapDelunoSeriesEndpoints();
+        app.MapDelunoJobsEndpoints();
+        app.MapDelunoDownloadClientIntegrationEndpoints();
+        app.MapDelunoSearchEndpoints();
+        app.MapDelunoMetadataEndpoints();
+        app.MapDelunoFilesystemEndpoints();
+        app.MapDelunoRealtime();
+        app.MapFallbackToFile("index.html");
+
+        await app.RunAsync();
+    }
+
+    private static string[] ResolveScopes(PathString path, string method)
+    {
+        var isRead = HttpMethods.IsGet(method) || HttpMethods.IsHead(method) || HttpMethods.IsOptions(method);
+        if (isRead) return ["read"];
+        if (path.StartsWithSegments("/api/download-clients", StringComparison.OrdinalIgnoreCase) ||
+            path.StartsWithSegments("/api/download-dispatches", StringComparison.OrdinalIgnoreCase))
+            return ["queue"];
+        if (path.StartsWithSegments("/api/filesystem/import", StringComparison.OrdinalIgnoreCase) ||
+            path.StartsWithSegments("/api/integrations", StringComparison.OrdinalIgnoreCase))
+            return ["imports", "queue"];
+        if (path.StartsWithSegments("/api/backups", StringComparison.OrdinalIgnoreCase))
+            return ["system"];
+        return ["write"];
+    }
+}

--- a/apps/windows-tray/ServiceManager.cs
+++ b/apps/windows-tray/ServiceManager.cs
@@ -1,0 +1,138 @@
+using System.Diagnostics;
+using System.ServiceProcess;
+
+namespace Deluno.Tray;
+
+public enum ServiceMode { Tray, ServiceLocalSystem, ServiceRunAsUser }
+
+public static class ServiceManager
+{
+    private const string ServiceName = "Deluno";
+    private static readonly string ExePath =
+        Path.Combine(AppContext.BaseDirectory, "Deluno.exe");
+
+    public static void Install(string[] args)
+    {
+        // args: --install-service [--username domain\user --password pass]
+        string? username = null, password = null;
+
+        for (int i = 0; i < args.Length - 1; i++)
+        {
+            if (args[i].Equals("--username", StringComparison.OrdinalIgnoreCase)) username = args[i + 1];
+            if (args[i].Equals("--password", StringComparison.OrdinalIgnoreCase)) password = args[i + 1];
+        }
+
+        Apply(
+            string.IsNullOrEmpty(username) ? ServiceMode.ServiceLocalSystem : ServiceMode.ServiceRunAsUser,
+            username, password);
+    }
+
+    public static void Uninstall()
+    {
+        RemoveService();
+        RemoveTrayStartup();
+    }
+
+    public static void Apply(ServiceMode mode, string? username, string? password)
+    {
+        RemoveService();
+        RemoveTrayStartup();
+
+        switch (mode)
+        {
+            case ServiceMode.Tray:
+                SetTrayStartup();
+                break;
+
+            case ServiceMode.ServiceLocalSystem:
+                CreateService(null, null);
+                break;
+
+            case ServiceMode.ServiceRunAsUser:
+                if (string.IsNullOrWhiteSpace(username))
+                    throw new ArgumentException("Username required for run-as-user service mode.");
+                CreateService(username, password);
+                break;
+        }
+    }
+
+    public static bool IsInstalled()
+    {
+        try
+        {
+            using var sc = new ServiceController(ServiceName);
+            _ = sc.Status;
+            return true;
+        }
+        catch { return false; }
+    }
+
+    public static ServiceControllerStatus? CurrentStatus()
+    {
+        try
+        {
+            using var sc = new ServiceController(ServiceName);
+            return sc.Status;
+        }
+        catch { return null; }
+    }
+
+    // ── Private helpers ────────────────────────────────────────────────────
+
+    private static void CreateService(string? username, string? password)
+    {
+        var binPath = $"\"{ExePath}\" --service";
+
+        // sc.exe is the simplest cross-version way to create a service with credentials
+        var scArgs = $"create {ServiceName} " +
+                     $"binPath= \"{binPath}\" " +
+                     $"start= auto " +
+                     $"DisplayName= \"Deluno Media Manager\"";
+
+        RunSc(scArgs);
+        RunSc($"description {ServiceName} \"Deluno media acquisition and management server\"");
+
+        if (!string.IsNullOrEmpty(username))
+        {
+            // Set the service logon account — requires a valid Windows account
+            RunSc($"config {ServiceName} obj= \"{username}\" password= \"{password ?? ""}\"");
+        }
+
+        // Start immediately
+        RunSc($"start {ServiceName}");
+    }
+
+    private static void RemoveService()
+    {
+        if (!IsInstalled()) return;
+        RunSc($"stop {ServiceName}");
+        RunSc($"delete {ServiceName}");
+    }
+
+    private static void SetTrayStartup()
+    {
+        var key = Microsoft.Win32.Registry.CurrentUser.OpenSubKey(
+            @"Software\Microsoft\Windows\CurrentVersion\Run", writable: true)!;
+        key.SetValue("Deluno", $"\"{ExePath}\"");
+    }
+
+    private static void RemoveTrayStartup()
+    {
+        var key = Microsoft.Win32.Registry.CurrentUser.OpenSubKey(
+            @"Software\Microsoft\Windows\CurrentVersion\Run", writable: true);
+        key?.DeleteValue("Deluno", throwOnMissingValue: false);
+    }
+
+    private static void RunSc(string args)
+    {
+        using var p = Process.Start(new ProcessStartInfo
+        {
+            FileName = "sc.exe",
+            Arguments = args,
+            UseShellExecute = true,
+            Verb = "runas",     // UAC elevation
+            CreateNoWindow = true
+        });
+        p?.WaitForExit();
+    }
+}

--- a/apps/windows-tray/ServiceModeDialog.cs
+++ b/apps/windows-tray/ServiceModeDialog.cs
@@ -1,0 +1,171 @@
+namespace Deluno.Tray;
+
+public sealed class ServiceModeDialog : Form
+{
+    public ServiceMode SelectedMode { get; private set; } = ServiceMode.Tray;
+    public string? ServiceUsername { get; private set; }
+    public string? ServicePassword { get; private set; }
+
+    private readonly RadioButton _rbTray;
+    private readonly RadioButton _rbLocalSystem;
+    private readonly RadioButton _rbRunAsUser;
+    private readonly TextBox _tbUsername;
+    private readonly TextBox _tbPassword;
+    private readonly Label _lblCredentials;
+    private readonly Button _btnOk;
+
+    public ServiceModeDialog()
+    {
+        Text = "Startup Mode";
+        FormBorderStyle = FormBorderStyle.FixedDialog;
+        MaximizeBox = false;
+        MinimizeBox = false;
+        StartPosition = FormStartPosition.CenterScreen;
+        ClientSize = new Size(420, 340);
+        Font = new Font("Segoe UI", 9f);
+
+        var panel = new Panel { Dock = DockStyle.Fill, Padding = new Padding(16) };
+
+        var lblTitle = new Label
+        {
+            Text = "Choose how Deluno starts with Windows:",
+            Font = new Font("Segoe UI", 9f, FontStyle.Bold),
+            AutoSize = true,
+            Location = new Point(16, 16)
+        };
+
+        _rbTray = new RadioButton
+        {
+            Text = "Start at login (recommended)",
+            Location = new Point(16, 48),
+            AutoSize = true,
+            Checked = true
+        };
+
+        var lblTrayDesc = new Label
+        {
+            Text = "Runs when you log in. Full access to network drives and mapped folders.",
+            ForeColor = SystemColors.GrayText,
+            Location = new Point(34, 68),
+            Size = new Size(370, 30)
+        };
+
+        _rbLocalSystem = new RadioButton
+        {
+            Text = "Windows Service — Local System",
+            Location = new Point(16, 108),
+            AutoSize = true
+        };
+
+        var lblLocalSystemDesc = new Label
+        {
+            Text = "Starts at boot before login. Cannot access mapped network drives or NAS shares.",
+            ForeColor = SystemColors.GrayText,
+            Location = new Point(34, 128),
+            Size = new Size(370, 30)
+        };
+
+        _rbRunAsUser = new RadioButton
+        {
+            Text = "Windows Service — Run as user",
+            Location = new Point(16, 168),
+            AutoSize = true
+        };
+
+        var lblRunAsUserDesc = new Label
+        {
+            Text = "Starts at boot with a specific account. Use this for NAS access at boot time.",
+            ForeColor = SystemColors.GrayText,
+            Location = new Point(34, 188),
+            Size = new Size(370, 30)
+        };
+
+        _lblCredentials = new Label
+        {
+            Text = "Windows account credentials:",
+            Location = new Point(34, 222),
+            AutoSize = true,
+            Visible = false
+        };
+
+        _tbUsername = new TextBox
+        {
+            PlaceholderText = "DOMAIN\\username or .\\localuser",
+            Location = new Point(34, 242),
+            Size = new Size(220, 23),
+            Visible = false
+        };
+
+        _tbPassword = new TextBox
+        {
+            PlaceholderText = "Password",
+            Location = new Point(262, 242),
+            Size = new Size(130, 23),
+            UseSystemPasswordChar = true,
+            Visible = false
+        };
+
+        _btnOk = new Button
+        {
+            Text = "Apply",
+            DialogResult = DialogResult.OK,
+            Location = new Point(240, 296),
+            Size = new Size(80, 28)
+        };
+        _btnOk.Click += OnOk;
+
+        var btnCancel = new Button
+        {
+            Text = "Cancel",
+            DialogResult = DialogResult.Cancel,
+            Location = new Point(328, 296),
+            Size = new Size(80, 28)
+        };
+
+        _rbRunAsUser.CheckedChanged += (_, _) =>
+        {
+            var show = _rbRunAsUser.Checked;
+            _lblCredentials.Visible = show;
+            _tbUsername.Visible     = show;
+            _tbPassword.Visible     = show;
+            ClientSize = show ? new Size(420, 380) : new Size(420, 340);
+        };
+
+        Controls.AddRange([
+            lblTitle,
+            _rbTray, lblTrayDesc,
+            _rbLocalSystem, lblLocalSystemDesc,
+            _rbRunAsUser, lblRunAsUserDesc,
+            _lblCredentials, _tbUsername, _tbPassword,
+            _btnOk, btnCancel
+        ]);
+
+        AcceptButton = _btnOk;
+        CancelButton = btnCancel;
+    }
+
+    private void OnOk(object? sender, EventArgs e)
+    {
+        if (_rbRunAsUser.Checked)
+        {
+            if (string.IsNullOrWhiteSpace(_tbUsername.Text))
+            {
+                MessageBox.Show("Please enter a Windows username.", "Deluno",
+                    MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                DialogResult = DialogResult.None;
+                return;
+            }
+            SelectedMode = ServiceMode.ServiceRunAsUser;
+            ServiceUsername = _tbUsername.Text.Trim();
+            ServicePassword = _tbPassword.Text;
+        }
+        else if (_rbLocalSystem.Checked)
+        {
+            SelectedMode = ServiceMode.ServiceLocalSystem;
+        }
+        else
+        {
+            SelectedMode = ServiceMode.Tray;
+        }
+    }
+}

--- a/apps/windows-tray/TrayApplication.cs
+++ b/apps/windows-tray/TrayApplication.cs
@@ -1,0 +1,234 @@
+using System.Diagnostics;
+using System.Reflection;
+
+namespace Deluno.Tray;
+
+public enum TrayState { Starting, Running, Degraded, Error, Updating, Stopped }
+
+public sealed class TrayApplication : ApplicationContext
+{
+    private readonly NotifyIcon _notify;
+    private readonly ToolStripMenuItem _openItem;
+    private readonly ToolStripMenuItem _restartItem;
+    private readonly ToolStripMenuItem _startStopItem;
+    private readonly ToolStripMenuItem _updateItem;
+    private readonly ToolStripMenuItem _serviceModeItem;
+    private readonly DelunoServer _server;
+    private readonly UpdateChecker _updater;
+    private TrayState _state = TrayState.Starting;
+    private string? _pendingUpdateVersion;
+
+    public TrayApplication()
+    {
+        _server = new DelunoServer();
+        _updater = new UpdateChecker();
+
+        _openItem       = new ToolStripMenuItem("Open Deluno",          null, OnOpen);
+        _restartItem    = new ToolStripMenuItem("Restart",              null, OnRestart) { Enabled = false };
+        _startStopItem  = new ToolStripMenuItem("Stop",                 null, OnStartStop) { Enabled = false };
+        _updateItem     = new ToolStripMenuItem("Check for Updates",    null, OnCheckUpdate);
+        _serviceModeItem = new ToolStripMenuItem("Run as Service...",   null, OnServiceMode);
+
+        var version = Assembly.GetEntryAssembly()!.GetName().Version;
+        var aboutItem = new ToolStripMenuItem($"Deluno v{version?.ToString(3) ?? "0.1.0"}") { Enabled = false };
+
+        var menu = new ContextMenuStrip();
+        menu.Items.AddRange([
+            _openItem,
+            new ToolStripSeparator(),
+            _restartItem,
+            _startStopItem,
+            new ToolStripSeparator(),
+            _serviceModeItem,
+            new ToolStripSeparator(),
+            _updateItem,
+            new ToolStripSeparator(),
+            aboutItem,
+            new ToolStripMenuItem("Quit", null, OnQuit)
+        ]);
+
+        _notify = new NotifyIcon
+        {
+            Text = "Deluno — Starting…",
+            Icon = TrayIconRenderer.Render(TrayState.Starting),
+            ContextMenuStrip = menu,
+            Visible = true
+        };
+        _notify.DoubleClick += OnOpen;
+
+        SetState(TrayState.Starting);
+        _ = StartServerAsync();
+        _ = ScheduleUpdateChecksAsync();
+    }
+
+    // ── State management ───────────────────────────────────────────────────
+
+    private void SetState(TrayState state)
+    {
+        _state = state;
+        _notify.Icon = TrayIconRenderer.Render(state);
+        _notify.Text = state switch
+        {
+            TrayState.Starting  => "Deluno — Starting…",
+            TrayState.Running   => $"Deluno — Running on port {AppSettings.Load().Port}",
+            TrayState.Degraded  => "Deluno — Running with warnings",
+            TrayState.Error     => "Deluno — Failed to start",
+            TrayState.Updating  => "Deluno — Updating…",
+            TrayState.Stopped   => "Deluno — Stopped",
+            _                   => "Deluno"
+        };
+
+        _openItem.Enabled     = state is TrayState.Running or TrayState.Degraded;
+        _restartItem.Enabled  = state is TrayState.Running or TrayState.Degraded or TrayState.Error;
+        _startStopItem.Enabled = state is not TrayState.Starting and not TrayState.Updating;
+        _startStopItem.Text   = state is TrayState.Stopped ? "Start" : "Stop";
+
+        if (_pendingUpdateVersion is not null)
+        {
+            _updateItem.Text = $"Update to {_pendingUpdateVersion}";
+            _updateItem.Font = new Font(_updateItem.Font, FontStyle.Bold);
+        }
+    }
+
+    // ── Server lifecycle ───────────────────────────────────────────────────
+
+    private async Task StartServerAsync()
+    {
+        try
+        {
+            SetState(TrayState.Starting);
+            await _server.StartAsync();
+            InvokeOnUiThread(() => SetState(TrayState.Running));
+        }
+        catch (Exception ex)
+        {
+            InvokeOnUiThread(() =>
+            {
+                SetState(TrayState.Error);
+                _notify.ShowBalloonTip(5000, "Deluno failed to start", ex.Message, ToolTipIcon.Error);
+            });
+        }
+    }
+
+    // ── Context menu handlers ──────────────────────────────────────────────
+
+    private void OnOpen(object? sender, EventArgs e)
+    {
+        if (_state is TrayState.Running or TrayState.Degraded)
+        {
+            var port = AppSettings.Load().Port;
+            Process.Start(new ProcessStartInfo($"http://localhost:{port}") { UseShellExecute = true });
+        }
+    }
+
+    private async void OnRestart(object? sender, EventArgs e)
+    {
+        _restartItem.Enabled = false;
+        await _server.StopAsync();
+        await StartServerAsync();
+    }
+
+    private async void OnStartStop(object? sender, EventArgs e)
+    {
+        if (_state is TrayState.Stopped)
+        {
+            await StartServerAsync();
+        }
+        else
+        {
+            await _server.StopAsync();
+            InvokeOnUiThread(() => SetState(TrayState.Stopped));
+        }
+    }
+
+    private async void OnCheckUpdate(object? sender, EventArgs e)
+    {
+        _updateItem.Enabled = false;
+        _updateItem.Text = "Checking…";
+
+        var update = await _updater.CheckAsync();
+        if (update is null)
+        {
+            _updateItem.Text = "Up to date";
+            await Task.Delay(3000);
+            _updateItem.Text = "Check for Updates";
+            _updateItem.Enabled = true;
+            return;
+        }
+
+        _pendingUpdateVersion = update.Version;
+        InvokeOnUiThread(() =>
+        {
+            SetState(_state); // refreshes update item label
+            _updateItem.Enabled = true;
+            _notify.ShowBalloonTip(6000,
+                $"Deluno {update.Version} available",
+                "Click 'Update to…' in the tray menu to install.",
+                ToolTipIcon.Info);
+        });
+    }
+
+    private async void OnServiceMode(object? sender, EventArgs e)
+    {
+        using var dialog = new ServiceModeDialog();
+        if (dialog.ShowDialog() != DialogResult.OK) return;
+
+        SetState(TrayState.Updating);
+        await _server.StopAsync();
+        ServiceManager.Apply(dialog.SelectedMode, dialog.ServiceUsername, dialog.ServicePassword);
+        Application.Exit();
+    }
+
+    private void OnQuit(object? sender, EventArgs e)
+    {
+        _server.StopAsync().GetAwaiter().GetResult();
+        _notify.Visible = false;
+        Application.Exit();
+    }
+
+    // ── Update scheduling ──────────────────────────────────────────────────
+
+    private async Task ScheduleUpdateChecksAsync()
+    {
+        // First check shortly after startup, then every 24 hours
+        await Task.Delay(TimeSpan.FromSeconds(30));
+        while (true)
+        {
+            var update = await _updater.CheckAsync();
+            if (update is not null)
+            {
+                _pendingUpdateVersion = update.Version;
+                InvokeOnUiThread(() =>
+                {
+                    SetState(_state);
+                    _notify.ShowBalloonTip(6000,
+                        $"Deluno {update.Version} available",
+                        "Open the tray menu to update.",
+                        ToolTipIcon.Info);
+                });
+            }
+            await Task.Delay(TimeSpan.FromHours(24));
+        }
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────
+
+    private void InvokeOnUiThread(Action action)
+    {
+        if (_notify.ContextMenuStrip?.InvokeRequired == true)
+            _notify.ContextMenuStrip.Invoke(action);
+        else
+            action();
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _notify.Visible = false;
+            _notify.Dispose();
+            _server.Dispose();
+        }
+        base.Dispose(disposing);
+    }
+}

--- a/apps/windows-tray/TrayIconRenderer.cs
+++ b/apps/windows-tray/TrayIconRenderer.cs
@@ -1,0 +1,84 @@
+using System.Drawing.Drawing2D;
+using System.Runtime.Versioning;
+
+namespace Deluno.Tray;
+
+[SupportedOSPlatform("windows")]
+public static class TrayIconRenderer
+{
+    // Renders a 16×16 icon for the given state using GDI+.
+    // Avoids shipping binary .ico files that would need updating with each brand change.
+    public static Icon Render(TrayState state)
+    {
+        const int size = 16;
+        using var bmp = new Bitmap(size, size);
+        using var g = Graphics.FromImage(bmp);
+        g.SmoothingMode = SmoothingMode.AntiAlias;
+        g.Clear(Color.Transparent);
+
+        // Background circle
+        var bg = BackgroundColor(state);
+        using var bgBrush = new SolidBrush(bg);
+        g.FillEllipse(bgBrush, 1, 1, size - 2, size - 2);
+
+        // State glyph
+        DrawGlyph(g, state, size);
+
+        return Icon.FromHandle(bmp.GetHicon());
+    }
+
+    private static Color BackgroundColor(TrayState state) => state switch
+    {
+        TrayState.Starting  => Color.FromArgb(100, 150, 220),   // blue-grey
+        TrayState.Running   => Color.FromArgb(52,  168, 83),    // green
+        TrayState.Degraded  => Color.FromArgb(251, 188, 5),     // amber
+        TrayState.Error     => Color.FromArgb(234, 67,  53),    // red
+        TrayState.Updating  => Color.FromArgb(66,  133, 244),   // blue
+        TrayState.Stopped   => Color.FromArgb(158, 158, 158),   // grey
+        _                   => Color.FromArgb(52,  168, 83)
+    };
+
+    private static void DrawGlyph(Graphics g, TrayState state, int size)
+    {
+        using var pen   = new Pen(Color.White, 1.5f);
+        using var brush = new SolidBrush(Color.White);
+        int cx = size / 2, cy = size / 2;
+
+        switch (state)
+        {
+            case TrayState.Running:
+                // Play-style "D" letterform (Deluno initial)
+                g.DrawString("D", new Font("Arial", 7f, FontStyle.Bold),
+                    brush, new PointF(4f, 3f));
+                break;
+
+            case TrayState.Starting:
+            case TrayState.Updating:
+                // Arc suggesting motion / loading
+                g.DrawArc(pen, 4, 4, size - 8, size - 8, -90, 270);
+                break;
+
+            case TrayState.Stopped:
+                // Square / stop symbol
+                g.FillRectangle(brush, cx - 3, cy - 3, 6, 6);
+                break;
+
+            case TrayState.Error:
+                // Exclamation mark
+                g.FillRectangle(brush, cx - 1, 4, 2, 5);
+                g.FillEllipse(brush, cx - 1, 11, 2, 2);
+                break;
+
+            case TrayState.Degraded:
+                // Warning triangle outline
+                var tri = new PointF[]
+                {
+                    new(cx, 4), new(cx + 4, 12), new(cx - 4, 12)
+                };
+                g.DrawPolygon(pen, tri);
+                g.FillRectangle(brush, cx - 1, 6, 2, 3);
+                g.FillEllipse(brush, cx - 1, 10, 2, 2);
+                break;
+        }
+    }
+}

--- a/apps/windows-tray/TrayIconRenderer.cs
+++ b/apps/windows-tray/TrayIconRenderer.cs
@@ -8,7 +8,7 @@ namespace Deluno.Tray;
 public static class TrayIconRenderer
 {
     // Renders a 16×16 icon matching the Deluno brand mark:
-    // screen outline + play triangle in white on a state-coloured background.
+    // film-frame screen (outline + side tabs) with a play triangle.
     public static Icon Render(TrayState state)
     {
         const int size = 16;
@@ -17,22 +17,29 @@ public static class TrayIconRenderer
         g.SmoothingMode = SmoothingMode.AntiAlias;
         g.Clear(Color.Transparent);
 
-        // Circular background in state colour
         using var bgBrush = new SolidBrush(StateColor(state));
         g.FillEllipse(bgBrush, 0, 0, size - 1, size - 1);
 
         using var whitePen   = new Pen(Color.White, 1.2f);
         using var whiteBrush = new SolidBrush(Color.White);
 
-        // Screen outline (rounded rect scaled to 16×16)
-        DrawRoundedRect(g, whitePen, 2, 4, 12, 9, 1.5f);
+        // Screen outline
+        DrawRoundedRect(g, whitePen, 2.5f, 5f, 11f, 6f, 1.2f);
 
-        // Play triangle
+        // Film strip tabs — left edge (two small filled rects straddling left stroke)
+        g.FillRectangle(whiteBrush, 1f, 6f,   2f, 1.5f);
+        g.FillRectangle(whiteBrush, 1f, 8.5f, 2f, 1.5f);
+
+        // Film strip tabs — right edge
+        g.FillRectangle(whiteBrush, 13f, 6f,   2f, 1.5f);
+        g.FillRectangle(whiteBrush, 13f, 8.5f, 2f, 1.5f);
+
+        // Play triangle, centred in screen
         g.FillPolygon(whiteBrush, new PointF[]
         {
-            new(7f,  6.5f),
-            new(7f,  10.5f),
-            new(11f, 8.5f),
+            new(6.5f, 6.5f),
+            new(6.5f, 10.5f),
+            new(11f,  8.5f),
         });
 
         return Icon.FromHandle(bmp.GetHicon());

--- a/apps/windows-tray/TrayIconRenderer.cs
+++ b/apps/windows-tray/TrayIconRenderer.cs
@@ -4,11 +4,13 @@ using System.Runtime.Versioning;
 
 namespace Deluno.Tray;
 
+// All geometry mirrors favicon.svg (100×100 viewBox) scaled to 16×16 (factor 0.16).
+// Screen : x=2.5 y=4 w=11 h=8  (70%×50% of icon, centred)
+// Tabs   : w=2 h=1.5, straddling left (x=2.5) and right (x=13.5) screen edges
+// Play ▶ : vertices (6.5,6.5) (6.5,9.5) (9.5,8)  — ~40% of screen height
 [SupportedOSPlatform("windows")]
 public static class TrayIconRenderer
 {
-    // Renders a 16×16 icon matching the Deluno brand mark:
-    // film-frame screen (outline + side tabs) with a play triangle.
     public static Icon Render(TrayState state)
     {
         const int size = 16;
@@ -20,26 +22,26 @@ public static class TrayIconRenderer
         using var bgBrush = new SolidBrush(StateColor(state));
         g.FillEllipse(bgBrush, 0, 0, size - 1, size - 1);
 
-        using var whitePen   = new Pen(Color.White, 1.2f);
-        using var whiteBrush = new SolidBrush(Color.White);
+        using var pen   = new Pen(Color.White, 1.1f);
+        using var brush = new SolidBrush(Color.White);
 
         // Screen outline
-        DrawRoundedRect(g, whitePen, 2.5f, 5f, 11f, 6f, 1.2f);
+        DrawRoundedRect(g, pen, 2.5f, 4f, 11f, 8f, 1.1f);
 
-        // Film strip tabs — left edge (two small filled rects straddling left stroke)
-        g.FillRectangle(whiteBrush, 1f, 6f,   2f, 1.5f);
-        g.FillRectangle(whiteBrush, 1f, 8.5f, 2f, 1.5f);
+        // Film strip tabs — left edge (straddle x=2.5)
+        g.FillRectangle(brush, 1.5f, 5.8f, 2f, 1.4f);
+        g.FillRectangle(brush, 1.5f, 8.8f, 2f, 1.4f);
 
-        // Film strip tabs — right edge
-        g.FillRectangle(whiteBrush, 13f, 6f,   2f, 1.5f);
-        g.FillRectangle(whiteBrush, 13f, 8.5f, 2f, 1.5f);
+        // Film strip tabs — right edge (straddle x=13.5)
+        g.FillRectangle(brush, 12.5f, 5.8f, 2f, 1.4f);
+        g.FillRectangle(brush, 12.5f, 8.8f, 2f, 1.4f);
 
-        // Play triangle, centred in screen
-        g.FillPolygon(whiteBrush, new PointF[]
+        // Play triangle
+        g.FillPolygon(brush, new PointF[]
         {
             new(6.5f, 6.5f),
-            new(6.5f, 10.5f),
-            new(11f,  8.5f),
+            new(6.5f, 9.5f),
+            new(9.5f, 8f),
         });
 
         return Icon.FromHandle(bmp.GetHicon());

--- a/apps/windows-tray/TrayIconRenderer.cs
+++ b/apps/windows-tray/TrayIconRenderer.cs
@@ -1,4 +1,5 @@
 using System.Drawing.Drawing2D;
+using System.Drawing.Imaging;
 using System.Runtime.Versioning;
 
 namespace Deluno.Tray;
@@ -6,79 +7,48 @@ namespace Deluno.Tray;
 [SupportedOSPlatform("windows")]
 public static class TrayIconRenderer
 {
-    // Renders a 16×16 icon for the given state using GDI+.
-    // Avoids shipping binary .ico files that would need updating with each brand change.
+    // Renders a 16×16 icon using the Deluno crescent-moon mark.
+    // Background colour changes per state; the crescent shape is always white.
     public static Icon Render(TrayState state)
     {
         const int size = 16;
-        using var bmp = new Bitmap(size, size);
-        using var g = Graphics.FromImage(bmp);
+        using var bmp = new Bitmap(size, size, PixelFormat.Format32bppArgb);
+        using var g   = Graphics.FromImage(bmp);
         g.SmoothingMode = SmoothingMode.AntiAlias;
         g.Clear(Color.Transparent);
 
-        // Background circle
-        var bg = BackgroundColor(state);
-        using var bgBrush = new SolidBrush(bg);
-        g.FillEllipse(bgBrush, 1, 1, size - 2, size - 2);
+        using var bgBrush = new SolidBrush(StateColor(state));
+        g.FillEllipse(bgBrush, 0, 0, size - 1, size - 1);
 
-        // State glyph
-        DrawGlyph(g, state, size);
+        DrawCrescent(g, Color.White);
 
         return Icon.FromHandle(bmp.GetHicon());
     }
 
-    private static Color BackgroundColor(TrayState state) => state switch
+    // Crescent geometry mirrors the favicon.svg (scaled to 16×16):
+    //   full moon  → ellipse at (2, 3, 11, 11)
+    //   bite circle → ellipse at (6, 0, 10, 10)  [offset upper-right]
+    private static void DrawCrescent(Graphics g, Color color)
     {
-        TrayState.Starting  => Color.FromArgb(100, 150, 220),   // blue-grey
-        TrayState.Running   => Color.FromArgb(52,  168, 83),    // green
-        TrayState.Degraded  => Color.FromArgb(251, 188, 5),     // amber
-        TrayState.Error     => Color.FromArgb(234, 67,  53),    // red
-        TrayState.Updating  => Color.FromArgb(66,  133, 244),   // blue
-        TrayState.Stopped   => Color.FromArgb(158, 158, 158),   // grey
-        _                   => Color.FromArgb(52,  168, 83)
-    };
+        using var fullPath = new GraphicsPath();
+        fullPath.AddEllipse(2f, 3f, 11f, 11f);
 
-    private static void DrawGlyph(Graphics g, TrayState state, int size)
-    {
-        using var pen   = new Pen(Color.White, 1.5f);
-        using var brush = new SolidBrush(Color.White);
-        int cx = size / 2, cy = size / 2;
+        using var region  = new Region(fullPath);
+        using var cutPath = new GraphicsPath();
+        cutPath.AddEllipse(6f, 0f, 10f, 10f);
+        region.Exclude(cutPath);
 
-        switch (state)
-        {
-            case TrayState.Running:
-                // Play-style "D" letterform (Deluno initial)
-                g.DrawString("D", new Font("Arial", 7f, FontStyle.Bold),
-                    brush, new PointF(4f, 3f));
-                break;
-
-            case TrayState.Starting:
-            case TrayState.Updating:
-                // Arc suggesting motion / loading
-                g.DrawArc(pen, 4, 4, size - 8, size - 8, -90, 270);
-                break;
-
-            case TrayState.Stopped:
-                // Square / stop symbol
-                g.FillRectangle(brush, cx - 3, cy - 3, 6, 6);
-                break;
-
-            case TrayState.Error:
-                // Exclamation mark
-                g.FillRectangle(brush, cx - 1, 4, 2, 5);
-                g.FillEllipse(brush, cx - 1, 11, 2, 2);
-                break;
-
-            case TrayState.Degraded:
-                // Warning triangle outline
-                var tri = new PointF[]
-                {
-                    new(cx, 4), new(cx + 4, 12), new(cx - 4, 12)
-                };
-                g.DrawPolygon(pen, tri);
-                g.FillRectangle(brush, cx - 1, 6, 2, 3);
-                g.FillEllipse(brush, cx - 1, 10, 2, 2);
-                break;
-        }
+        using var brush = new SolidBrush(color);
+        g.FillRegion(brush, region);
     }
+
+    private static Color StateColor(TrayState state) => state switch
+    {
+        TrayState.Running  => Color.FromArgb(0x22, 0xC5, 0x5E),  // green-500
+        TrayState.Degraded => Color.FromArgb(0xF5, 0x9E, 0x0B),  // amber-500
+        TrayState.Error    => Color.FromArgb(0xEF, 0x44, 0x44),  // red-500
+        TrayState.Starting => Color.FromArgb(0x63, 0x66, 0xF1),  // indigo-500 (brand)
+        TrayState.Updating => Color.FromArgb(0x63, 0x66, 0xF1),  // indigo-500 (brand)
+        _                  => Color.FromArgb(0x6B, 0x72, 0x80),  // gray-500
+    };
 }

--- a/apps/windows-tray/TrayIconRenderer.cs
+++ b/apps/windows-tray/TrayIconRenderer.cs
@@ -7,8 +7,8 @@ namespace Deluno.Tray;
 [SupportedOSPlatform("windows")]
 public static class TrayIconRenderer
 {
-    // Renders a 16×16 icon using the Deluno crescent-moon mark.
-    // Background colour changes per state; the crescent shape is always white.
+    // Renders a 16×16 icon matching the Deluno brand mark:
+    // screen outline + play triangle in white on a state-coloured background.
     public static Icon Render(TrayState state)
     {
         const int size = 16;
@@ -17,38 +17,45 @@ public static class TrayIconRenderer
         g.SmoothingMode = SmoothingMode.AntiAlias;
         g.Clear(Color.Transparent);
 
+        // Circular background in state colour
         using var bgBrush = new SolidBrush(StateColor(state));
         g.FillEllipse(bgBrush, 0, 0, size - 1, size - 1);
 
-        DrawCrescent(g, Color.White);
+        using var whitePen   = new Pen(Color.White, 1.2f);
+        using var whiteBrush = new SolidBrush(Color.White);
+
+        // Screen outline (rounded rect scaled to 16×16)
+        DrawRoundedRect(g, whitePen, 2, 4, 12, 9, 1.5f);
+
+        // Play triangle
+        g.FillPolygon(whiteBrush, new PointF[]
+        {
+            new(7f,  6.5f),
+            new(7f,  10.5f),
+            new(11f, 8.5f),
+        });
 
         return Icon.FromHandle(bmp.GetHicon());
     }
 
-    // Crescent geometry mirrors the favicon.svg (scaled to 16×16):
-    //   full moon  → ellipse at (2, 3, 11, 11)
-    //   bite circle → ellipse at (6, 0, 10, 10)  [offset upper-right]
-    private static void DrawCrescent(Graphics g, Color color)
+    private static void DrawRoundedRect(Graphics g, Pen pen, float x, float y, float w, float h, float r)
     {
-        using var fullPath = new GraphicsPath();
-        fullPath.AddEllipse(2f, 3f, 11f, 11f);
-
-        using var region  = new Region(fullPath);
-        using var cutPath = new GraphicsPath();
-        cutPath.AddEllipse(6f, 0f, 10f, 10f);
-        region.Exclude(cutPath);
-
-        using var brush = new SolidBrush(color);
-        g.FillRegion(brush, region);
+        using var path = new GraphicsPath();
+        path.AddArc(x, y, r * 2, r * 2, 180, 90);
+        path.AddArc(x + w - r * 2, y, r * 2, r * 2, 270, 90);
+        path.AddArc(x + w - r * 2, y + h - r * 2, r * 2, r * 2, 0, 90);
+        path.AddArc(x, y + h - r * 2, r * 2, r * 2, 90, 90);
+        path.CloseFigure();
+        g.DrawPath(pen, path);
     }
 
     private static Color StateColor(TrayState state) => state switch
     {
-        TrayState.Running  => Color.FromArgb(0x22, 0xC5, 0x5E),  // green-500
-        TrayState.Degraded => Color.FromArgb(0xF5, 0x9E, 0x0B),  // amber-500
-        TrayState.Error    => Color.FromArgb(0xEF, 0x44, 0x44),  // red-500
-        TrayState.Starting => Color.FromArgb(0x63, 0x66, 0xF1),  // indigo-500 (brand)
-        TrayState.Updating => Color.FromArgb(0x63, 0x66, 0xF1),  // indigo-500 (brand)
-        _                  => Color.FromArgb(0x6B, 0x72, 0x80),  // gray-500
+        TrayState.Running  => Color.FromArgb(0xF5, 0xA6, 0x23),  // brand orange
+        TrayState.Degraded => Color.FromArgb(0xF5, 0x9E, 0x0B),  // amber
+        TrayState.Error    => Color.FromArgb(0xEF, 0x44, 0x44),  // red
+        TrayState.Starting => Color.FromArgb(0xF5, 0xA6, 0x23),  // brand orange
+        TrayState.Updating => Color.FromArgb(0x63, 0x66, 0xF1),  // indigo
+        _                  => Color.FromArgb(0x6B, 0x72, 0x80),  // gray
     };
 }

--- a/apps/windows-tray/UpdateChecker.cs
+++ b/apps/windows-tray/UpdateChecker.cs
@@ -1,0 +1,152 @@
+using System.Reflection;
+using System.Security.Cryptography;
+using System.Text.Json;
+
+namespace Deluno.Tray;
+
+public sealed class UpdateInfo
+{
+    public string Version { get; init; } = "";
+    public string InstallerUrl { get; init; } = "";
+    public string Sha256 { get; init; } = "";
+}
+
+public sealed class UpdateChecker
+{
+    private const string ReleasesApiUrl =
+        "https://api.github.com/repos/jampat000/Deluno/releases/latest";
+
+    private readonly HttpClient _http = new()
+    {
+        DefaultRequestHeaders = { { "User-Agent", "Deluno-Tray-Updater" } }
+    };
+
+    public async Task<UpdateInfo?> CheckAsync()
+    {
+        try
+        {
+            var json = await _http.GetStringAsync(ReleasesApiUrl);
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+
+            var tagName = root.GetProperty("tag_name").GetString() ?? "";
+            var releaseVersion = tagName.TrimStart('v');
+            var currentVersion = Assembly.GetEntryAssembly()!
+                .GetName().Version?.ToString(3) ?? "0.0.0";
+
+            if (!IsNewer(releaseVersion, currentVersion))
+                return null;
+
+            // Find the Windows installer asset
+            var assets = root.GetProperty("assets");
+            string? installerUrl = null;
+            foreach (var asset in assets.EnumerateArray())
+            {
+                var name = asset.GetProperty("name").GetString() ?? "";
+                if (name.EndsWith(".exe", StringComparison.OrdinalIgnoreCase) &&
+                    name.Contains("Setup", StringComparison.OrdinalIgnoreCase))
+                {
+                    installerUrl = asset.GetProperty("browser_download_url").GetString();
+                    break;
+                }
+            }
+
+            if (installerUrl is null) return null;
+
+            // Extract SHA256 from release body ("abc123  Deluno-Setup-x.y.z.exe")
+            var body = root.GetProperty("body").GetString() ?? "";
+            var sha256 = ParseSha256FromReleaseBody(body, releaseVersion);
+
+            return new UpdateInfo
+            {
+                Version = releaseVersion,
+                InstallerUrl = installerUrl,
+                Sha256 = sha256
+            };
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    public async Task<bool> DownloadAndInstallAsync(UpdateInfo update, IProgress<int>? progress = null)
+    {
+        var tempDir  = Path.Combine(Path.GetTempPath(), "DelunoUpdate");
+        var destPath = Path.Combine(tempDir, $"Deluno-Setup-{update.Version}.exe");
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            // Download
+            using var response = await _http.GetAsync(
+                update.InstallerUrl, HttpCompletionOption.ResponseHeadersRead);
+            response.EnsureSuccessStatusCode();
+
+            var total = response.Content.Headers.ContentLength ?? -1L;
+            await using var src  = await response.Content.ReadAsStreamAsync();
+            await using var dest = File.Create(destPath);
+
+            var buffer = new byte[81920];
+            long downloaded = 0;
+            int read;
+            while ((read = await src.ReadAsync(buffer)) > 0)
+            {
+                await dest.WriteAsync(buffer.AsMemory(0, read));
+                downloaded += read;
+                if (total > 0)
+                    progress?.Report((int)(downloaded * 100 / total));
+            }
+
+            // Verify SHA256
+            if (!string.IsNullOrEmpty(update.Sha256))
+            {
+                dest.Position = 0;
+                var actual = Convert.ToHexString(await SHA256.HashDataAsync(dest)).ToLowerInvariant();
+                if (!string.Equals(actual, update.Sha256.ToLowerInvariant()))
+                    throw new InvalidOperationException(
+                        "SHA256 checksum mismatch — installer may be corrupted or tampered with.");
+            }
+
+            // Run installer silently; it will close this process automatically
+            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+            {
+                FileName  = destPath,
+                Arguments = "/SILENT /CLOSEAPPLICATIONS /RESTARTAPPLICATIONS",
+                UseShellExecute = true
+            });
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show(
+                $"Update failed: {ex.Message}\n\nPlease download manually from GitHub.",
+                "Deluno Update", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            return false;
+        }
+    }
+
+    private static bool IsNewer(string candidate, string current)
+    {
+        return Version.TryParse(candidate, out var c) &&
+               Version.TryParse(current,   out var cur) &&
+               c > cur;
+    }
+
+    private static string ParseSha256FromReleaseBody(string body, string version)
+    {
+        // Expected line format in release notes:
+        // "abc123def...  Deluno-Setup-1.0.0.exe"
+        foreach (var line in body.Split('\n'))
+        {
+            if (line.Contains($"Deluno-Setup-{version}.exe", StringComparison.OrdinalIgnoreCase))
+            {
+                var parts = line.Trim().Split("  ", 2);
+                if (parts.Length == 2 && parts[0].Length == 64)
+                    return parts[0].Trim();
+            }
+        }
+        return "";
+    }
+}

--- a/installer/deluno-setup.iss
+++ b/installer/deluno-setup.iss
@@ -1,0 +1,322 @@
+; Deluno Windows Installer — Inno Setup 6
+; Compiled by CI: ISCC.exe deluno-setup.iss /DAppVersion=x.y.z /DBinDir=..\..\artifacts\windows\bin
+
+#ifndef AppVersion
+  #define AppVersion "0.1.0"
+#endif
+#ifndef BinDir
+  #define BinDir "..\..\artifacts\windows\bin"
+#endif
+
+#define AppName      "Deluno"
+#define AppPublisher "Deluno"
+#define AppURL       "https://github.com/jampat000/Deluno"
+#define AppExeName   "Deluno.exe"
+#define ServiceName  "Deluno"
+#define DataDir      "{commonappdata}\Deluno\data"
+#define BinInstDir   "{commonappdata}\Deluno\bin"
+
+[Setup]
+AppId                    = {{A7F3C2D1-8B4E-4F9A-BC23-5D1E7F8A9C0B}
+AppName                  = {#AppName}
+AppVersion               = {#AppVersion}
+AppPublisher             = {#AppPublisher}
+AppPublisherURL          = {#AppURL}
+AppSupportURL            = {#AppURL}/issues
+AppUpdatesURL            = {#AppURL}/releases
+DefaultDirName           = {commonappdata}\Deluno
+DefaultGroupName         = {#AppName}
+DisableDirPage           = yes
+DisableProgramGroupPage  = yes
+OutputDir                = ..\artifacts\windows\installer
+OutputBaseFilename       = Deluno-Setup-{#AppVersion}
+Compression              = lzma2/ultra64
+SolidCompression         = yes
+WizardStyle              = modern
+WizardSizePercent        = 110
+SetupIconFile            =
+UninstallDisplayName     = {#AppName} {#AppVersion}
+CloseApplications        = yes
+RestartApplications      = yes
+PrivilegesRequired       = admin
+PrivilegesRequiredOverridesAllowed = commandline
+MinVersion               = 10.0
+ArchitecturesInstallIn64BitMode = x64compatible
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+
+; ── Custom pages ──────────────────────────────────────────────────────────────
+
+[Code]
+var
+  StartupPage:    TWizardPage;
+  RbTray:         TRadioButton;
+  RbLocalSystem:  TRadioButton;
+  RbRunAsUser:    TRadioButton;
+  LblUsername:    TLabel;
+  TbUsername:     TEdit;
+  LblPassword:    TLabel;
+  TbPassword:     TEdit;
+  LblNasWarning:  TLabel;
+
+  PortPage:       TWizardPage;
+  TbPort:         TEdit;
+  LblPortStatus:  TLabel;
+
+procedure UpdateCredentialVisibility(Sender: TObject);
+begin
+  LblUsername.Visible   := RbRunAsUser.Checked;
+  TbUsername.Visible    := RbRunAsUser.Checked;
+  LblPassword.Visible   := RbRunAsUser.Checked;
+  TbPassword.Visible    := RbRunAsUser.Checked;
+  LblNasWarning.Visible := RbLocalSystem.Checked;
+end;
+
+procedure ValidatePort(Sender: TObject);
+var
+  Port: Integer;
+begin
+  Port := StrToIntDef(TbPort.Text, 0);
+  if (Port < 1024) or (Port > 65535) then
+    LblPortStatus.Caption := '✗  Enter a port between 1024 and 65535'
+  else
+    LblPortStatus.Caption := '✓  Port ' + TbPort.Text + ' looks good';
+end;
+
+procedure InitializeWizard;
+begin
+  { ── Startup mode page ── }
+  StartupPage := CreateCustomPage(wpWelcome, 'Startup Mode',
+    'Choose how Deluno starts with Windows.');
+
+  RbTray := TRadioButton.Create(StartupPage);
+  RbTray.Parent  := StartupPage.Surface;
+  RbTray.Caption := 'Start at login (recommended)';
+  RbTray.Left    := 0; RbTray.Top := 0;
+  RbTray.Width   := 400; RbTray.Checked := True;
+  RbTray.OnClick := @UpdateCredentialVisibility;
+
+  with TLabel.Create(StartupPage) do begin
+    Parent  := StartupPage.Surface;
+    Caption := 'Runs when you log in. Full access to network drives and NAS shares.';
+    Left := 20; Top := 22; Width := 380;
+    Font.Color := clGray;
+  end;
+
+  RbLocalSystem := TRadioButton.Create(StartupPage);
+  RbLocalSystem.Parent  := StartupPage.Surface;
+  RbLocalSystem.Caption := 'Windows Service — Local System account';
+  RbLocalSystem.Left := 0; RbLocalSystem.Top := 56;
+  RbLocalSystem.Width := 400;
+  RbLocalSystem.OnClick := @UpdateCredentialVisibility;
+
+  LblNasWarning := TLabel.Create(StartupPage);
+  LblNasWarning.Parent  := StartupPage.Surface;
+  LblNasWarning.Caption :=
+    'Starts at boot. Cannot access mapped drives or NAS shares requiring credentials.';
+  LblNasWarning.Left := 20; LblNasWarning.Top := 78; LblNasWarning.Width := 380;
+  LblNasWarning.Font.Color := $004080C0;
+  LblNasWarning.Visible := False;
+
+  RbRunAsUser := TRadioButton.Create(StartupPage);
+  RbRunAsUser.Parent  := StartupPage.Surface;
+  RbRunAsUser.Caption := 'Windows Service — Run as specific user (NAS / network drives at boot)';
+  RbRunAsUser.Left := 0; RbRunAsUser.Top := 116;
+  RbRunAsUser.Width := 400;
+  RbRunAsUser.OnClick := @UpdateCredentialVisibility;
+
+  LblUsername := TLabel.Create(StartupPage);
+  LblUsername.Parent  := StartupPage.Surface;
+  LblUsername.Caption := 'Windows username (e.g. .\John or DOMAIN\John):';
+  LblUsername.Left := 20; LblUsername.Top := 142; LblUsername.Width := 380;
+  LblUsername.Visible := False;
+
+  TbUsername := TEdit.Create(StartupPage);
+  TbUsername.Parent  := StartupPage.Surface;
+  TbUsername.Left := 20; TbUsername.Top := 160; TbUsername.Width := 360;
+  TbUsername.Visible := False;
+
+  LblPassword := TLabel.Create(StartupPage);
+  LblPassword.Parent  := StartupPage.Surface;
+  LblPassword.Caption := 'Password:';
+  LblPassword.Left := 20; LblPassword.Top := 192; LblPassword.Width := 380;
+  LblPassword.Visible := False;
+
+  TbPassword := TEdit.Create(StartupPage);
+  TbPassword.Parent     := StartupPage.Surface;
+  TbPassword.Left := 20; TbPassword.Top := 210; TbPassword.Width := 360;
+  TbPassword.PasswordChar := '*';
+  TbPassword.Visible := False;
+
+  { ── Port page ── }
+  PortPage := CreateCustomPage(StartupPage.ID, 'Network Port',
+    'Choose the port Deluno listens on.');
+
+  with TLabel.Create(PortPage) do begin
+    Parent  := PortPage.Surface;
+    Caption :=
+      'Deluno will be accessible at http://localhost:[port]' + #13#10 +
+      'The default port 7879 works for most installations.';
+    Left := 0; Top := 0; Width := 400;
+  end;
+
+  with TLabel.Create(PortPage) do begin
+    Parent  := PortPage.Surface;
+    Caption := 'Port number:';
+    Left := 0; Top := 52;
+  end;
+
+  TbPort := TEdit.Create(PortPage);
+  TbPort.Parent  := PortPage.Surface;
+  TbPort.Text    := '7879';
+  TbPort.Left := 0; TbPort.Top := 70; TbPort.Width := 100;
+  TbPort.OnChange := @ValidatePort;
+
+  LblPortStatus := TLabel.Create(PortPage);
+  LblPortStatus.Parent  := PortPage.Surface;
+  LblPortStatus.Caption := '✓  Port 7879 looks good';
+  LblPortStatus.Left := 110; LblPortStatus.Top := 74;
+  LblPortStatus.Font.Color := clGreen;
+  LblPortStatus.Width := 280;
+end;
+
+function NextButtonClick(CurPageID: Integer): Boolean;
+begin
+  Result := True;
+
+  if CurPageID = StartupPage.ID then begin
+    if RbRunAsUser.Checked and (Trim(TbUsername.Text) = '') then begin
+      MsgBox('Please enter a Windows username for the service account.', mbError, MB_OK);
+      Result := False;
+    end;
+  end;
+
+  if CurPageID = PortPage.ID then begin
+    if (StrToIntDef(TbPort.Text, 0) < 1024) or (StrToIntDef(TbPort.Text, 0) > 65535) then begin
+      MsgBox('Please enter a valid port number (1024–65535).', mbError, MB_OK);
+      Result := False;
+    end;
+  end;
+end;
+
+procedure WriteAppConfig;
+var
+  ConfigPath: String;
+  Json:       String;
+  DataPath:   String;
+begin
+  DataPath   := ExpandConstant('{commonappdata}\Deluno\data');
+  ConfigPath := DataPath + '\deluno.json';
+
+  ForceDirectories(DataPath);
+
+  Json := '{"port":' + TbPort.Text + ',' +
+          '"dataRoot":"' + StringReplace(DataPath, '\', '\\', [rfReplaceAll]) + '"}';
+
+  SaveStringToFile(ConfigPath, Json, False);
+end;
+
+procedure ApplyStartupMode;
+var
+  ExePath:    String;
+  ResultCode: Integer;
+begin
+  ExePath := ExpandConstant('{commonappdata}\Deluno\bin\Deluno.exe');
+
+  if RbTray.Checked then
+  begin
+    RegWriteStringValue(HKCU,
+      'Software\Microsoft\Windows\CurrentVersion\Run',
+      'Deluno', '"' + ExePath + '"');
+    RegDeleteValue(HKLM, 'SYSTEM\CurrentControlSet\Services\Deluno', 'ImagePath');
+    Exec('sc.exe', 'delete Deluno', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+  end
+  else if RbLocalSystem.Checked then
+  begin
+    RegDeleteValue(HKCU,
+      'Software\Microsoft\Windows\CurrentVersion\Run', 'Deluno');
+    Exec(ExePath, '--install-service', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+  end
+  else if RbRunAsUser.Checked then
+  begin
+    RegDeleteValue(HKCU,
+      'Software\Microsoft\Windows\CurrentVersion\Run', 'Deluno');
+    Exec(ExePath,
+      '--install-service --username "' + TbUsername.Text +
+      '" --password "' + TbPassword.Text + '"',
+      '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+  end;
+end;
+
+procedure CurStepChanged(CurStep: TSetupStep);
+begin
+  if CurStep = ssPostInstall then
+  begin
+    WriteAppConfig;
+    ApplyStartupMode;
+  end;
+end;
+
+procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
+var
+  DataDir:    String;
+  ResultCode: Integer;
+begin
+  if CurUninstallStep = usUninstall then
+  begin
+    { Stop and remove service if present }
+    Exec('sc.exe', 'stop Deluno',   '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+    Exec('sc.exe', 'delete Deluno', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+    RegDeleteValue(HKCU,
+      'Software\Microsoft\Windows\CurrentVersion\Run', 'Deluno');
+  end;
+
+  if CurUninstallStep = usPostUninstall then
+  begin
+    DataDir := ExpandConstant('{commonappdata}\Deluno\data');
+    if MsgBox(
+      'Do you want to delete all Deluno data?' + #13#10 +
+      '(database, configuration, logs)' + #13#10#13#10 +
+      DataDir + #13#10#13#10 +
+      'Leave unticked to keep your settings for a future reinstall.',
+      mbConfirmation, MB_YESNO) = IDYES then
+    begin
+      DelTree(DataDir, True, True, True);
+    end;
+  end;
+end;
+
+[Files]
+; All published tray app files
+Source: "{#BinDir}\*"; DestDir: "{#BinInstDir}"; \
+  Flags: ignoreversion recursesubdirs createallsubdirs; \
+  Excludes: "*.pdb"
+
+[Icons]
+Name: "{group}\Deluno";           Filename: "{#BinInstDir}\{#AppExeName}"
+Name: "{group}\Uninstall Deluno"; Filename: "{uninstallexe}"
+Name: "{commonstartup}\Deluno";   Filename: "{#BinInstDir}\{#AppExeName}"; \
+  Check: not RbTray.Checked  ; Tasks: not startuptask
+
+[Tasks]
+Name: startuptask; \
+  Description: "Start Deluno automatically when Windows starts"; \
+  Check: RbTray.Checked
+
+[Run]
+Filename: "{#BinInstDir}\{#AppExeName}"; \
+  Description: "Start Deluno now"; \
+  Flags: nowait postinstall skipifsilent; \
+  Check: RbTray.Checked
+
+Filename: "http://localhost:{code:GetPort}"; \
+  Description: "Open Deluno in browser"; \
+  Flags: nowait postinstall skipifsilent shellexec; \
+  Check: RbTray.Checked
+
+[Code]
+function GetPort(Param: String): String;
+begin
+  Result := TbPort.Text;
+end;

--- a/scripts/ci-check.sh
+++ b/scripts/ci-check.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Mirrors the GitHub Actions CI pipeline.
+# Run before every push: bash scripts/ci-check.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+echo "▶  Restoring backend..."
+dotnet restore Deluno.slnx -q
+
+echo "▶  Building backend (Release)..."
+dotnet build Deluno.slnx --configuration Release --no-restore -q
+
+echo "▶  Installing frontend dependencies..."
+npm ci --silent
+
+echo "▶  Building frontend..."
+npm run build:web --silent
+
+echo "▶  Agent readiness..."
+if command -v pwsh &>/dev/null; then
+  pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/validate-agent-readiness.ps1
+else
+  powershell -NoProfile -ExecutionPolicy Bypass -File scripts/validate-agent-readiness.ps1
+fi
+
+echo ""
+echo "✓  All checks passed — safe to push."


### PR DESCRIPTION
## Summary

- **Windows tray app** (`apps/windows-tray/`) — single `Deluno.exe` that hosts the full ASP.NET Core server in-process, with a system tray icon, three startup modes, and seamless auto-update
- **Inno Setup installer** (`installer/deluno-setup.iss`) — wizard-based setup with custom startup mode and port selection pages, writes `deluno.json`, registers tray or service, prompts to delete data on uninstall
- **GitHub Actions release workflow** (`.github/workflows/release.yml`) — Docker multi-arch image to ghcr.io on every `main` push; Windows installer + SHA256 + GitHub Release on `v*` tags

## Tray app details

| Feature | Detail |
|---|---|
| Startup modes | Tray (login), Service-LocalSystem (boot, no NAS), Service-RunAsUser (boot + NAS) |
| Install path | `C:\ProgramData\Deluno\bin\` — no elevation needed for self-updates |
| Tray states | Starting / Running / Degraded / Error / Updating / Stopped — GDI+ programmatic icons |
| Auto-update | Polls GitHub Releases API every 24h, verifies SHA256, runs installer `/SILENT /CLOSEAPPLICATIONS` |
| Single-instance | Mutex + `PostMessage(WM_DELUNO_SHOW)` to bring existing instance to focus |
| Service install | `sc.exe` via `runas` verb (UAC-elevated) — no embedded admin manifest needed |

## Release workflow

- **Docker**: `linux/amd64` + `linux/arm64` via QEMU + Buildx → `ghcr.io/jampat000/deluno`
  - Tags: `latest` + `sha-<short>` on `main`; semver `1.2.3`, `1.2`, `1` on `v*` tags
- **Windows**: frontend build → `dotnet publish` → ISCC.exe → SHA256 → artifact + GitHub Release

## Test plan

- [ ] `dotnet build apps/windows-tray/Deluno.Tray.csproj` compiles clean on Windows
- [ ] Installer wizard shows startup mode page then port page
- [ ] Tray mode: registers HKCU Run key, app starts and shows system tray icon
- [ ] Service mode: `sc query Deluno` shows service, accessible at configured port
- [ ] Docker workflow: push to main triggers image build and push to ghcr.io
- [ ] Release workflow: push `v0.1.0` tag triggers installer build + GitHub Release with `.exe` and `.sha256` attached

🤖 Generated with [Claude Code](https://claude.com/claude-code)