### PR TITLE
fix(release): fix tray build errors and Docker restore failures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,15 @@ COPY src/Deluno.Realtime/Deluno.Realtime.csproj ./src/Deluno.Realtime/
 COPY src/Deluno.Series/Deluno.Series.csproj ./src/Deluno.Series/
 COPY src/Deluno.Worker/Deluno.Worker.csproj ./src/Deluno.Worker/
 
+# Tray app (Windows-only; restore still runs on Linux with EnableWindowsTargeting=true)
+COPY apps/windows-tray/Deluno.Tray.csproj ./apps/windows-tray/
+
+# Test projects (restore only; tests are not run in the Docker build)
+COPY tests/Deluno.Integrations.Tests/Deluno.Integrations.Tests.csproj ./tests/Deluno.Integrations.Tests/
+COPY tests/Deluno.Movies.Tests/Deluno.Movies.Tests.csproj ./tests/Deluno.Movies.Tests/
+COPY tests/Deluno.Persistence.Tests/Deluno.Persistence.Tests.csproj ./tests/Deluno.Persistence.Tests/
+COPY tests/Deluno.Platform.Tests/Deluno.Platform.Tests.csproj ./tests/Deluno.Platform.Tests/
+
 RUN dotnet restore ./Deluno.slnx
 
 COPY src ./src

--- a/apps/windows-tray/Deluno.Tray.csproj
+++ b/apps/windows-tray/Deluno.Tray.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>net10.0-windows</TargetFramework>
     <OutputType>WinExe</OutputType>

--- a/apps/windows-tray/DelunoServer.cs
+++ b/apps/windows-tray/DelunoServer.cs
@@ -2,6 +2,8 @@ using Deluno.Api;
 using Deluno.Api.Backup;
 using Deluno.Filesystem;
 using Deluno.Infrastructure;
+using Deluno.Infrastructure.Observability;
+using Deluno.Integrations;
 using Deluno.Integrations.DownloadClients;
 using Deluno.Integrations.Metadata;
 using Deluno.Integrations.Search;

--- a/apps/windows-tray/ServiceHost.cs
+++ b/apps/windows-tray/ServiceHost.cs
@@ -2,6 +2,8 @@ using Deluno.Api;
 using Deluno.Api.Backup;
 using Deluno.Filesystem;
 using Deluno.Infrastructure;
+using Deluno.Infrastructure.Observability;
+using Deluno.Integrations;
 using Deluno.Integrations.DownloadClients;
 using Deluno.Integrations.Metadata;
 using Deluno.Integrations.Search;


### PR DESCRIPTION
## What was broken

The Release workflow has been failing on every push since the installer was introduced. Two separate bugs:

**1. Windows tray build — CS1061 extension method errors**
`ServiceHost.cs` and `DelunoServer.cs` were missing two `using` directives that are present in `Deluno.Host/Program.cs`:
- `using Deluno.Infrastructure.Observability;` → needed for `UseDelunoCorrelation`
- `using Deluno.Integrations;` → needed for `AddDelunoIntegrationsModule`

Also switched the tray project SDK from `Microsoft.NET.Sdk` to `Microsoft.NET.Sdk.Web` (same as `Deluno.Host`) so all ASP.NET Core APIs are in scope without needing extra package references.

**2. Docker build — MSB3202 project files not found**
`dotnet restore ./Deluno.slnx` was failing because the Dockerfile's csproj-copy cache layer only covered `src/` projects. The solution also references the tray app and all test projects, none of which were being `COPY`'d before the restore step.

Fixed by adding `COPY` lines for:
- `apps/windows-tray/Deluno.Tray.csproj`
- `tests/Deluno.Integrations.Tests/Deluno.Integrations.Tests.csproj`
- `tests/Deluno.Movies.Tests/Deluno.Movies.Tests.csproj`
- `tests/Deluno.Persistence.Tests/Deluno.Persistence.Tests.csproj`
- `tests/Deluno.Platform.Tests/Deluno.Platform.Tests.csproj`

## Verified
- `dotnet build apps/windows-tray/Deluno.Tray.csproj --configuration Release` → 0 errors
- `bash scripts/ci-check.sh` → passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)