### PR TITLE
fix(installer): use IsTrayMode function instead of RbTray.Checked in [Run] Check

### DIFF
--- a/installer/deluno-setup.iss
+++ b/installer/deluno-setup.iss
@@ -63,13 +63,13 @@ Name: "{group}\Uninstall Deluno"; Filename: "{uninstallexe}"
 Filename: "{#BinInstDir}\{#AppExeName}"; \
   Description: "Start Deluno now"; \
   Flags: nowait postinstall skipifsilent; \
-  Check: RbTray.Checked
+  Check: IsTrayMode
 
 ; Tray mode: open browser to the configured port
 Filename: "http://localhost:{code:GetPort}"; \
   Description: "Open Deluno in your browser"; \
   Flags: nowait postinstall skipifsilent shellexec; \
-  Check: RbTray.Checked
+  Check: IsTrayMode
 
 ; ── Custom pages and install logic ────────────────────────────────────────────
 
@@ -88,6 +88,12 @@ var
   PortPage:       TWizardPage;
   TbPort:         TEdit;
   LblPortStatus:  TLabel;
+
+{ Called from [Run] Check: — true when tray mode is selected }
+function IsTrayMode: Boolean;
+begin
+  Result := RbTray.Checked;
+end;
 
 { Called from [Run] — returns the port the user chose }
 function GetPort(Param: String): String;


### PR DESCRIPTION
## What was broken

The Windows installer was failing to compile with Inno Setup 6:

```
Error on line 63: Directive or parameter \"Check\" expression error: Invalid symbol '.' found.
```

Inno Setup's `Check:` parameter in `[Run]` sections only accepts a **function name** — it cannot evaluate dotted property expressions like `RbTray.Checked` directly.

## Fix

Added a `IsTrayMode()` Boolean helper in the `[Code]` section and updated both `[Run]` entries to reference it:

```pascal
function IsTrayMode: Boolean;
begin
  Result := RbTray.Checked;
end;
```

```ini
Check: IsTrayMode   { was: Check: RbTray.Checked }
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)"