### PR TITLE
fix(installer): correct BinDir path — one level up from installer/, not two

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,7 +128,7 @@ jobs:
           $iscc = "C:\Program Files (x86)\Inno Setup 6\ISCC.exe"
           & $iscc installer/deluno-setup.iss `
             /DAppVersion=${{ steps.version.outputs.version }} `
-            /DBinDir=..\..\artifacts\windows\bin
+            /DBinDir=..\artifacts\windows\bin
         working-directory: ${{ github.workspace }}
 
       - name: Compute SHA256

--- a/installer/deluno-setup.iss
+++ b/installer/deluno-setup.iss
@@ -63,13 +63,13 @@ Name: "{group}\Uninstall Deluno"; Filename: "{uninstallexe}"
 Filename: "{#BinInstDir}\{#AppExeName}"; \
   Description: "Start Deluno now"; \
   Flags: nowait postinstall skipifsilent; \
-  Check: RbTray.Checked
+  Check: IsTrayMode
 
 ; Tray mode: open browser to the configured port
 Filename: "http://localhost:{code:GetPort}"; \
   Description: "Open Deluno in your browser"; \
   Flags: nowait postinstall skipifsilent shellexec; \
-  Check: RbTray.Checked
+  Check: IsTrayMode
 
 ; ── Custom pages and install logic ────────────────────────────────────────────
 
@@ -88,6 +88,12 @@ var
   PortPage:       TWizardPage;
   TbPort:         TEdit;
   LblPortStatus:  TLabel;
+
+{ Called from [Run] Check: — true when tray mode is selected }
+function IsTrayMode: Boolean;
+begin
+  Result := RbTray.Checked;
+end;
 
 { Called from [Run] — returns the port the user chose }
 function GetPort(Param: String): String;

--- a/installer/deluno-setup.iss
+++ b/installer/deluno-setup.iss
@@ -1,11 +1,11 @@
 ; Deluno Windows Installer — Inno Setup 6
-; Compiled by CI: ISCC.exe deluno-setup.iss /DAppVersion=x.y.z /DBinDir=..\..\artifacts\windows\bin
+; Compiled by CI: ISCC.exe deluno-setup.iss /DAppVersion=x.y.z /DBinDir=..\artifacts\windows\bin
 
 #ifndef AppVersion
   #define AppVersion "0.1.0"
 #endif
 #ifndef BinDir
-  #define BinDir "..\..\artifacts\windows\bin"
+  #define BinDir "..\artifacts\windows\bin"
 #endif
 
 #define AppName      "Deluno"


### PR DESCRIPTION
## What was broken

Inno Setup was failing with:
```
No files found matching "D:\a\Deluno\Deluno\installer\..\..\artifacts\windows\bin\*"
```

ISCC resolves `[Files]` `Source:` paths **relative to the `.iss` file's directory** (`installer/`). The BinDir was set to `..\..\artifacts\windows\bin` — two levels up from `installer/` overshoots the workspace root (`D:\a\Deluno\`) instead of landing at `D:\a\Deluno\Deluno\artifacts\windows\bin`.

## Fix

Changed `/DBinDir=..\..\artifacts\windows\bin` → `/DBinDir=..\artifacts\windows\bin` in the workflow, and updated the matching default and comment in `deluno-setup.iss` for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)