### PR TITLE
fix(installer): replace StringReplace with StringChange in Pascal Script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,7 +128,7 @@ jobs:
           $iscc = "C:\Program Files (x86)\Inno Setup 6\ISCC.exe"
           & $iscc installer/deluno-setup.iss `
             /DAppVersion=${{ steps.version.outputs.version }} `
-            /DBinDir=..\..\artifacts\windows\bin
+            /DBinDir=..\artifacts\windows\bin
         working-directory: ${{ github.workspace }}
 
       - name: Compute SHA256

--- a/installer/deluno-setup.iss
+++ b/installer/deluno-setup.iss
@@ -63,13 +63,13 @@ Name: "{group}\Uninstall Deluno"; Filename: "{uninstallexe}"
 Filename: "{#BinInstDir}\{#AppExeName}"; \
   Description: "Start Deluno now"; \
   Flags: nowait postinstall skipifsilent; \
-  Check: RbTray.Checked
+  Check: IsTrayMode
 
 ; Tray mode: open browser to the configured port
 Filename: "http://localhost:{code:GetPort}"; \
   Description: "Open Deluno in your browser"; \
   Flags: nowait postinstall skipifsilent shellexec; \
-  Check: RbTray.Checked
+  Check: IsTrayMode
 
 ; ── Custom pages and install logic ────────────────────────────────────────────
 
@@ -88,6 +88,12 @@ var
   PortPage:       TWizardPage;
   TbPort:         TEdit;
   LblPortStatus:  TLabel;
+
+{ Called from [Run] Check: — true when tray mode is selected }
+function IsTrayMode: Boolean;
+begin
+  Result := RbTray.Checked;
+end;
 
 { Called from [Run] — returns the port the user chose }
 function GetPort(Param: String): String;

--- a/installer/deluno-setup.iss
+++ b/installer/deluno-setup.iss
@@ -239,17 +239,20 @@ end;
 
 procedure WriteAppConfig;
 var
-  ConfigPath: String;
-  Json:       String;
-  DataPath:   String;
+  ConfigPath:   String;
+  Json:         String;
+  DataPath:     String;
+  EscapedPath:  String;
 begin
   DataPath   := ExpandConstant('{commonappdata}\Deluno\data');
   ConfigPath := DataPath + '\deluno.json';
 
   ForceDirectories(DataPath);
 
+  EscapedPath := DataPath;
+  StringChange(EscapedPath, '\', '\\');  { StringChange is Inno Setup's in-place replace }
   Json := '{"port":' + TbPort.Text + ',' +
-          '"dataRoot":"' + StringReplace(DataPath, '\', '\\', [rfReplaceAll]) + '"}';
+          '"dataRoot":"' + EscapedPath + '"}';
 
   SaveStringToFile(ConfigPath, Json, False);
 end;

--- a/installer/deluno-setup.iss
+++ b/installer/deluno-setup.iss
@@ -1,11 +1,11 @@
 ; Deluno Windows Installer — Inno Setup 6
-; Compiled by CI: ISCC.exe deluno-setup.iss /DAppVersion=x.y.z /DBinDir=..\..\artifacts\windows\bin
+; Compiled by CI: ISCC.exe deluno-setup.iss /DAppVersion=x.y.z /DBinDir=..\artifacts\windows\bin
 
 #ifndef AppVersion
   #define AppVersion "0.1.0"
 #endif
 #ifndef BinDir
-  #define BinDir "..\..\artifacts\windows\bin"
+  #define BinDir "..\artifacts\windows\bin"
 #endif
 
 #define AppName      "Deluno"


### PR DESCRIPTION
## What was broken

```
Error on line 252: Unknown identifier 'StringReplace'
```

Inno Setup's Pascal Script is a restricted Pascal implementation — it does not include Delphi's `SysUtils.StringReplace()`. The `[rfReplaceAll]` flag set syntax is also not supported.

## Fix

Use the built-in `StringChange(var S: String; OldValue, NewValue: String)` which modifies the string in-place and replaces all occurrences by default — exactly what was needed for escaping backslashes in the JSON config path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)