### PR TITLE
fix: resolve priority backlog scoring and dashboard issues

### DIFF
--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,10 +1,11 @@
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { defineConfig, devices } from "@playwright/test";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, "../..");
-const smokeDataRoot = path.join(repoRoot, ".playwright-data");
+const smokeDataRoot = path.join(os.tmpdir(), "deluno-playwright", `${process.pid}-${Date.now()}`);
 
 export default defineConfig({
   testDir: "./tests",

--- a/apps/web/src/components/app/cf-creator.tsx
+++ b/apps/web/src/components/app/cf-creator.tsx
@@ -37,6 +37,7 @@ export interface CFCondition {
 
 export interface CFDraft {
   name: string;
+  mediaType: "movies" | "tv";
   category: CFCategory;
   conditions: CFCondition[];
 }
@@ -93,6 +94,7 @@ function RegexPreview({ condition }: { condition: CFCondition }) {
 export function CFCreator({ onSave, onCancel, initial }: Props) {
   const [draft, setDraft] = useState<CFDraft>({
     name: initial?.name ?? "",
+    mediaType: initial?.mediaType ?? "movies",
     category: initial?.category ?? "misc",
     conditions: initial?.conditions ?? [emptyCondition()],
   });
@@ -146,6 +148,33 @@ export function CFCreator({ onSave, onCancel, initial }: Props) {
           placeholder="e.g. My Preferred Groups"
           className="h-10"
         />
+      </div>
+
+      {/* Category */}
+      <div className="space-y-1.5">
+        <label className="text-[11px] font-bold uppercase tracking-[0.14em] text-muted-foreground">
+          Media type
+        </label>
+        <div className="flex gap-2">
+          {[
+            { id: "movies", label: "Movies" },
+            { id: "tv", label: "TV" }
+          ].map((option) => (
+            <button
+              key={option.id}
+              type="button"
+              onClick={() => setDraft((d) => ({ ...d, mediaType: option.id as "movies" | "tv" }))}
+              className={cn(
+                "rounded-full border px-3 py-1.5 text-[11.5px] font-medium transition-all",
+                draft.mediaType === option.id
+                  ? "border-primary/40 bg-primary/10 text-foreground"
+                  : "border-hairline text-muted-foreground hover:border-primary/20"
+              )}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
       </div>
 
       {/* Category */}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -201,6 +201,18 @@ export interface SeriesInventoryDetail {
   episodes: SeriesEpisodeInventoryItem[];
 }
 
+export interface SeriesUpcomingEpisodeItem {
+  seriesId: string;
+  title: string;
+  startYear: number | null;
+  posterUrl: string | null;
+  episodeId: string;
+  seasonNumber: number;
+  episodeNumber: number;
+  episodeTitle: string | null;
+  airDateUtc: string;
+}
+
 export interface SeriesSearchHistoryItem {
   id: string;
   seriesId: string;

--- a/apps/web/src/routes/dashboard-page.tsx
+++ b/apps/web/src/routes/dashboard-page.tsx
@@ -23,7 +23,7 @@ import {
   type MovieWantedSummary,
   type SearchCycleRunItem,
   type SearchRetryWindowItem,
-  type SeriesInventoryDetail,
+  type SeriesUpcomingEpisodeItem,
   type SeriesListItem,
   type SeriesWantedSummary
 } from "../lib/api";
@@ -73,7 +73,7 @@ interface DashboardUpcomingItem {
 }
 
 export async function dashboardLoader(): Promise<DashboardLoaderData> {
-  const [movieItems, movieWanted, showItems, showWanted, telemetry, indexers, clients, automation, searchCycles, retryWindows] = await Promise.all([
+  const [movieItems, movieWanted, showItems, showWanted, telemetry, indexers, clients, automation, searchCycles, retryWindows, upcomingEpisodes] = await Promise.all([
     fetchJson<MovieListItem[]>("/api/movies"),
     fetchJson<MovieWantedSummary>("/api/movies/wanted"),
     fetchJson<SeriesListItem[]>("/api/series"),
@@ -83,20 +83,18 @@ export async function dashboardLoader(): Promise<DashboardLoaderData> {
     fetchJson<DownloadClientItem[]>("/api/download-clients"),
     fetchJson<LibraryAutomationStateItem[]>("/api/library-automation"),
     fetchJson<SearchCycleRunItem[]>("/api/search-cycles?take=8"),
-    fetchJson<SearchRetryWindowItem[]>("/api/search-retry-windows?take=8")
+    fetchJson<SearchRetryWindowItem[]>("/api/search-retry-windows?take=8"),
+    fetchJson<SeriesUpcomingEpisodeItem[]>("/api/series/upcoming?take=12&hours=72")
   ]);
 
-    const adaptedMovies = adaptMovieItems(movieItems, movieWanted);
-    const adaptedShows = adaptSeriesItems(showItems, showWanted);
-    const allItems = [...adaptedMovies, ...adaptedShows];
-    const seriesInventory = await Promise.all(
-      showItems.map((item) => fetchJson<SeriesInventoryDetail>(`/api/series/${item.id}/inventory`).catch(() => null))
-    );
-    const activeDownloads = adaptTelemetryDownloads(telemetry);
-    const indexerHealth = adaptIndexerHealth(indexers, clients);
-    const librarySizeGb = allItems.reduce((sum, item) => sum + (item.sizeGb ?? 0), 0);
-    const monitoredCount = allItems.filter((item) => item.monitored).length;
-    const healthyCount = indexerHealth.filter((item) => item.status === "healthy").length;
+  const adaptedMovies = adaptMovieItems(movieItems, movieWanted);
+  const adaptedShows = adaptSeriesItems(showItems, showWanted);
+  const allItems = [...adaptedMovies, ...adaptedShows];
+  const activeDownloads = adaptTelemetryDownloads(telemetry);
+  const indexerHealth = adaptIndexerHealth(indexers, clients);
+  const librarySizeGb = allItems.reduce((sum, item) => sum + (item.sizeGb ?? 0), 0);
+  const monitoredCount = allItems.filter((item) => item.monitored).length;
+  const healthyCount = indexerHealth.filter((item) => item.status === "healthy").length;
 
   return {
     activeDownloads,
@@ -111,7 +109,7 @@ export async function dashboardLoader(): Promise<DashboardLoaderData> {
       .sort((left, right) => right.added.localeCompare(left.added))
       .slice(0, 14),
     totalCount: allItems.length,
-    upcoming: buildDashboardUpcoming(seriesInventory, showItems, showWanted, movieWanted),
+    upcoming: buildDashboardUpcoming(upcomingEpisodes, showWanted, movieWanted),
     upgradeCount: movieWanted.upgradeCount + showWanted.upgradeCount,
     waitingCount: movieWanted.waitingCount + showWanted.waitingCount,
     automation,
@@ -630,36 +628,27 @@ function shortQuality(value: string | null) {
 }
 
 function buildDashboardUpcoming(
-  inventories: Array<SeriesInventoryDetail | null>,
-  series: SeriesListItem[],
+  episodes: SeriesUpcomingEpisodeItem[],
   seriesWanted: SeriesWantedSummary,
   movieWanted: MovieWantedSummary
 ): DashboardUpcomingItem[] {
   const now = Date.now();
   const horizon = now + 1000 * 60 * 60 * 72;
-  const seriesById = new Map(series.map((item) => [item.id, item]));
 
-  const episodeItems = inventories
-    .filter((item): item is SeriesInventoryDetail => item !== null)
-    .flatMap((inventory) => {
-      const seriesItem = seriesById.get(inventory.seriesId);
-
-      return inventory.episodes
-        .filter((episode) => episode.airDateUtc)
-        .map((episode) => ({ episode, time: new Date(episode.airDateUtc!).getTime() }))
-        .filter(({ time }) => time >= now && time <= horizon)
-        .map(({ episode, time }) => ({
-          id: episode.episodeId,
-          day: formatDashboardDay(new Date(time)),
-          title: inventory.title,
-          episode: `S${String(episode.seasonNumber).padStart(2, "0")}E${String(episode.episodeNumber).padStart(2, "0")}`,
-          dateLabel: formatDashboardTime(new Date(time)),
-          network: episode.title ?? "Upcoming episode",
-          poster: seriesItem?.posterUrl ?? null,
-          href: `/tv/${inventory.seriesId}`,
-          startsAt: episode.airDateUtc!
-        }));
-    });
+  const episodeItems = episodes
+    .map((episode) => ({ episode, time: new Date(episode.airDateUtc).getTime() }))
+    .filter(({ time }) => time >= now && time <= horizon)
+    .map(({ episode, time }) => ({
+      id: episode.episodeId,
+      day: formatDashboardDay(new Date(time)),
+      title: episode.title,
+      episode: `S${String(episode.seasonNumber).padStart(2, "0")}E${String(episode.episodeNumber).padStart(2, "0")}`,
+      dateLabel: formatDashboardTime(new Date(time)),
+      network: episode.episodeTitle ?? "Upcoming episode",
+      poster: episode.posterUrl ?? null,
+      href: `/tv/${episode.seriesId}`,
+      startsAt: episode.airDateUtc
+    }));
 
   const retryItems = [
     ...seriesWanted.recentItems
@@ -670,7 +659,7 @@ function buildDashboardUpcoming(
         title: item.title,
         episode: "Retry",
         network: item.wantedReason,
-        poster: seriesById.get(item.seriesId)?.posterUrl ?? null,
+        poster: null,
         href: `/tv/${item.seriesId}`,
         startsAt: item.nextEligibleSearchUtc!
       })),

--- a/apps/web/src/routes/movie-detail-page.tsx
+++ b/apps/web/src/routes/movie-detail-page.tsx
@@ -159,8 +159,12 @@ export function MovieDetailPage() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           releaseName: candidate.releaseName,
+          indexerId: candidate.indexerId,
           indexerName: candidate.indexerName,
+          candidateQuality: candidate.quality,
           downloadUrl: candidate.downloadUrl,
+          sizeBytes: candidate.sizeBytes,
+          seeders: candidate.seeders,
           force,
           overrideReason: force ? overrideReason || `User forced this release despite scorer result: ${candidate.summary}` : null
         })
@@ -756,6 +760,7 @@ function MetadataCorrectionPanel({
 
 interface SearchPlanCandidate {
   releaseName: string;
+  indexerId?: string | null;
   indexerName: string;
   quality: string;
   score: number;
@@ -945,6 +950,7 @@ function normalizeSearchCandidate(value: SearchPlanCandidate | Record<string, un
   const item = value as Record<string, unknown>;
   return {
     releaseName: String(item.releaseName ?? item.ReleaseName ?? ""),
+    indexerId: (item.indexerId ?? item.IndexerId ?? null) as string | null,
     indexerName: String(item.indexerName ?? item.IndexerName ?? ""),
     quality: String(item.quality ?? item.Quality ?? ""),
     score: Number(item.score ?? item.Score ?? 0),

--- a/apps/web/src/routes/settings-custom-formats-page.tsx
+++ b/apps/web/src/routes/settings-custom-formats-page.tsx
@@ -76,6 +76,7 @@ function conditionSummary(rawConditions: string | null | undefined): string {
 interface DryRunResult {
   formatId: string;
   formatName: string;
+  mediaType: string;
   score: number;
   isMatch: boolean;
   matchedConditions: string[];
@@ -140,6 +141,7 @@ export function SettingsCustomFormatsPage() {
 
   const [tab, setTab] = useState<Tab>("library");
   const [busyKey, setBusyKey] = useState<string | null>(null);
+  const [libraryMediaType, setLibraryMediaType] = useState<"movies" | "tv">("movies");
 
   /**
    * Library selections — maps trashId → score. In real implementation,
@@ -148,14 +150,21 @@ export function SettingsCustomFormatsPage() {
   const [librarySelections, setLibrarySelections] = useState<Map<string, number>>(() => {
     const m = new Map<string, number>();
     for (const cf of customFormats) {
-      if (cf.trashId) m.set(cf.trashId, cf.score);
+      if (cf.trashId) m.set(customFormatSelectionKey(cf.mediaType, cf.trashId), cf.score);
     }
     return m;
   });
 
+  const visibleLibrarySelections = new Map(
+    customFormats
+      .filter((cf) => cf.trashId && cf.mediaType === libraryMediaType)
+      .map((cf) => [cf.trashId as string, cf.score])
+  );
+
   /* ── Library selection handlers ── */
   async function handleLibraryAdd(cf: BundledCF, score: number) {
-    setLibrarySelections((prev) => new Map(prev).set(cf.trashId, score));
+    const selectionKey = customFormatSelectionKey(libraryMediaType, cf.trashId);
+    setLibrarySelections((prev) => new Map(prev).set(selectionKey, score));
     try {
       // Serialize patterns as structured JSON conditions (releaseTitle type)
       const conditions = serializeConditions(
@@ -166,7 +175,7 @@ export function SettingsCustomFormatsPage() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           name: cf.name,
-          mediaType: "movies",
+          mediaType: libraryMediaType,
           score,
           trashId: cf.trashId,
           conditions,
@@ -177,7 +186,7 @@ export function SettingsCustomFormatsPage() {
       toast.success(`Added "${cf.name}" to your formats`);
       revalidator.revalidate();
     } catch (e) {
-      setLibrarySelections((prev) => { const m = new Map(prev); m.delete(cf.trashId); return m; });
+      setLibrarySelections((prev) => { const m = new Map(prev); m.delete(selectionKey); return m; });
       toast.error(e instanceof Error ? e.message : "Could not add format.");
     }
   }
@@ -190,7 +199,8 @@ export function SettingsCustomFormatsPage() {
       })
       .filter((entry): entry is { cf: BundledCF; score: number } => Boolean(entry));
 
-    const missing = formats.filter(({ cf }) => !librarySelections.has(cf.trashId));
+    const targetMediaType = bundle.mediaType === "tv" ? "tv" : "movies";
+    const missing = formats.filter(({ cf }) => !librarySelections.has(customFormatSelectionKey(targetMediaType, cf.trashId)));
     if (missing.length === 0) {
       toast.info(`"${bundle.name}" is already applied.`);
       return;
@@ -199,7 +209,7 @@ export function SettingsCustomFormatsPage() {
     setBusyKey(`bundle:${bundle.id}`);
     setLibrarySelections((prev) => {
       const next = new Map(prev);
-      for (const { cf, score } of missing) next.set(cf.trashId, score);
+      for (const { cf, score } of missing) next.set(customFormatSelectionKey(targetMediaType, cf.trashId), score);
       return next;
     });
 
@@ -213,7 +223,7 @@ export function SettingsCustomFormatsPage() {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             name: cf.name,
-            mediaType: bundle.mediaType === "tv" ? "tv" : "movies",
+            mediaType: targetMediaType,
             score,
             trashId: cf.trashId,
             conditions,
@@ -228,7 +238,7 @@ export function SettingsCustomFormatsPage() {
     } catch (error) {
       setLibrarySelections((prev) => {
         const next = new Map(prev);
-        for (const { cf } of missing) next.delete(cf.trashId);
+        for (const { cf } of missing) next.delete(customFormatSelectionKey(targetMediaType, cf.trashId));
         return next;
       });
       toast.error(error instanceof Error ? error.message : "Preset could not be applied.");
@@ -238,13 +248,17 @@ export function SettingsCustomFormatsPage() {
   }
 
   function handleLibraryRemove(trashId: string) {
-    const cf = customFormats.find((c) => c.trashId === trashId);
+    const cf = customFormats.find((c) => c.trashId === trashId && c.mediaType === libraryMediaType);
     if (cf) void handleDelete(cf.id, trashId);
-    else setLibrarySelections((prev) => { const m = new Map(prev); m.delete(trashId); return m; });
+    else setLibrarySelections((prev) => {
+      const m = new Map(prev);
+      m.delete(customFormatSelectionKey(libraryMediaType, trashId));
+      return m;
+    });
   }
 
   function handleLibraryScoreChange(trashId: string, score: number) {
-    setLibrarySelections((prev) => new Map(prev).set(trashId, score));
+    setLibrarySelections((prev) => new Map(prev).set(customFormatSelectionKey(libraryMediaType, trashId), score));
   }
 
   /* ── User CF handlers ── */
@@ -254,7 +268,12 @@ export function SettingsCustomFormatsPage() {
       const res = await authedFetch(`/api/custom-formats/${id}`, { method: "DELETE" });
       if (!res.ok && res.status !== 204) throw new Error("Could not remove format.");
       if (trashId) {
-        setLibrarySelections((prev) => { const m = new Map(prev); m.delete(trashId); return m; });
+        setLibrarySelections((prev) => {
+          const m = new Map(prev);
+          m.delete(customFormatSelectionKey("movies", trashId));
+          m.delete(customFormatSelectionKey("tv", trashId));
+          return m;
+        });
       }
       toast.success("Custom format removed");
       revalidator.revalidate();
@@ -289,8 +308,9 @@ export function SettingsCustomFormatsPage() {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         name: draft.name,
-        mediaType: "movies",
+        mediaType: draft.mediaType,
         score: 100,
+        trashId: null,
         conditions,
         upgradeAllowed: true,
       }),
@@ -338,12 +358,19 @@ export function SettingsCustomFormatsPage() {
 
       {/* ── Library tab ── */}
       {tab === "library" && (
-        <CFLibraryBrowser
-          selections={librarySelections}
-          onAdd={handleLibraryAdd}
-          onRemove={handleLibraryRemove}
-          onScoreChange={handleLibraryScoreChange}
-        />
+        <div className="space-y-4">
+          <MediaTypePills
+            value={libraryMediaType}
+            onChange={(value) => setLibraryMediaType(value as "movies" | "tv")}
+            description="Choose which library type these built-in formats should be created for."
+          />
+          <CFLibraryBrowser
+            selections={visibleLibrarySelections}
+            onAdd={handleLibraryAdd}
+            onRemove={handleLibraryRemove}
+            onScoreChange={handleLibraryScoreChange}
+          />
+        </div>
       )}
 
       {/* ── My formats tab ── */}
@@ -443,6 +470,7 @@ export function SettingsCustomFormatsPage() {
 /* ── Dry-run panel ───────────────────────────────────────────────── */
 function DryRunPanel({ formats }: { formats: CustomFormatItem[] }) {
   const [releaseName, setReleaseName] = useState("");
+  const [mediaType, setMediaType] = useState<"all" | "movies" | "tv">("all");
   const [results, setResults] = useState<DryRunResult[] | null>(null);
   const [loading, setLoading] = useState(false);
 
@@ -453,7 +481,7 @@ function DryRunPanel({ formats }: { formats: CustomFormatItem[] }) {
       const data = await fetchJson<DryRunResult[]>("/api/custom-formats/dry-run", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ releaseName: releaseName.trim() }),
+        body: JSON.stringify({ releaseName: releaseName.trim(), mediaType: mediaType === "all" ? null : mediaType }),
       });
       setResults(data);
     } catch {
@@ -471,6 +499,16 @@ function DryRunPanel({ formats }: { formats: CustomFormatItem[] }) {
       {/* Input */}
       <div className="rounded-2xl border border-hairline bg-surface-1 p-5">
         <p className="mb-2 text-[12px] font-semibold uppercase tracking-widest text-muted-foreground">Release name</p>
+        <MediaTypePills
+          value={mediaType}
+          onChange={(value) => setMediaType(value as "all" | "movies" | "tv")}
+          options={[
+            { value: "all", label: "All formats" },
+            { value: "movies", label: "Movies" },
+            { value: "tv", label: "TV" }
+          ]}
+          description="Limit the dry-run to movie formats, TV formats, or both."
+        />
         <div className="flex gap-3">
           <input
             type="text"
@@ -514,6 +552,7 @@ function DryRunPanel({ formats }: { formats: CustomFormatItem[] }) {
                   <div className="flex items-center gap-2">
                     <CheckCircle2 className="h-4 w-4 text-primary" />
                     <span className="font-medium text-foreground">{r.formatName}</span>
+                    <FormatMediaTypeBadge mediaType={r.mediaType} />
                     <span className="rounded-full border border-primary/20 bg-primary/10 px-2 py-0.5 font-mono text-[10px] font-bold text-primary">
                       {r.score > 0 ? "+" : ""}{r.score}
                     </span>
@@ -540,6 +579,7 @@ function DryRunPanel({ formats }: { formats: CustomFormatItem[] }) {
                 <div key={r.formatId} className="rounded-2xl border border-hairline bg-surface-1 p-3">
                   <div className="flex items-center gap-2">
                     <span className="font-medium text-muted-foreground">{r.formatName}</span>
+                    <FormatMediaTypeBadge mediaType={r.mediaType} />
                     <span className="rounded-full border border-hairline px-2 py-0.5 font-mono text-[10px] text-muted-foreground">{r.score > 0 ? "+" : ""}{r.score}</span>
                   </div>
                   {r.missedConditions.length > 0 && (
@@ -558,6 +598,56 @@ function DryRunPanel({ formats }: { formats: CustomFormatItem[] }) {
         </div>
       )}
     </div>
+  );
+}
+
+function customFormatSelectionKey(mediaType: string, trashId: string): string {
+  return `${mediaType}:${trashId}`;
+}
+
+function MediaTypePills({
+  value,
+  onChange,
+  description,
+  options = [
+    { value: "movies", label: "Movies" },
+    { value: "tv", label: "TV" }
+  ]
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  description?: string;
+  options?: Array<{ value: string; label: string }>;
+}) {
+  return (
+    <div className="space-y-2">
+      <div className="flex flex-wrap gap-2">
+        {options.map((option) => (
+          <button
+            key={option.value}
+            type="button"
+            onClick={() => onChange(option.value)}
+            className={cn(
+              "rounded-full border px-3 py-1.5 text-[11.5px] font-medium transition-all",
+              value === option.value
+                ? "border-primary/40 bg-primary/10 text-foreground"
+                : "border-hairline text-muted-foreground hover:border-primary/20"
+            )}
+          >
+            {option.label}
+          </button>
+        ))}
+      </div>
+      {description ? <p className="text-[12px] text-muted-foreground">{description}</p> : null}
+    </div>
+  );
+}
+
+function FormatMediaTypeBadge({ mediaType }: { mediaType: string }) {
+  return (
+    <span className="rounded-full border border-hairline px-2 py-0.5 text-[9.5px] font-semibold uppercase tracking-wide text-muted-foreground">
+      {mediaType === "tv" ? "TV" : "Movies"}
+    </span>
   );
 }
 
@@ -595,7 +685,8 @@ function PresetBundles({
           const resolved = bundle.includes
             .map((entry) => findBundledCF(entry.trashId))
             .filter((cf): cf is BundledCF => Boolean(cf));
-          const appliedCount = resolved.filter((cf) => selections.has(cf.trashId)).length;
+          const bundleMediaType = bundle.mediaType === "tv" ? "tv" : "movies";
+          const appliedCount = resolved.filter((cf) => selections.has(customFormatSelectionKey(bundleMediaType, cf.trashId))).length;
           const totalCount = resolved.length;
           const isComplete = totalCount > 0 && appliedCount === totalCount;
           const isBusy = busyKey === `bundle:${bundle.id}`;

--- a/apps/web/src/routes/show-detail-page.tsx
+++ b/apps/web/src/routes/show-detail-page.tsx
@@ -203,8 +203,12 @@ export function ShowDetailPage() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           releaseName: candidate.releaseName,
+          indexerId: candidate.indexerId,
           indexerName: candidate.indexerName,
+          candidateQuality: candidate.quality,
           downloadUrl: candidate.downloadUrl,
+          sizeBytes: candidate.sizeBytes,
+          seeders: candidate.seeders,
           force,
           overrideReason: force ? overrideReason || `User forced this release despite scorer result: ${candidate.summary}` : null
         })
@@ -1130,6 +1134,7 @@ function formatWantedStatus(value: string) {
 
 interface SearchPlanCandidate {
   releaseName: string;
+  indexerId?: string | null;
   indexerName: string;
   quality: string;
   score: number;
@@ -1319,6 +1324,7 @@ function normalizeSearchCandidate(value: SearchPlanCandidate | Record<string, un
   const item = value as Record<string, unknown>;
   return {
     releaseName: String(item.releaseName ?? item.ReleaseName ?? ""),
+    indexerId: (item.indexerId ?? item.IndexerId ?? null) as string | null,
     indexerName: String(item.indexerName ?? item.IndexerName ?? ""),
     quality: String(item.quality ?? item.Quality ?? ""),
     score: Number(item.score ?? item.Score ?? 0),

--- a/src/Deluno.Integrations/Search/AcquisitionDecisionPipeline.cs
+++ b/src/Deluno.Integrations/Search/AcquisitionDecisionPipeline.cs
@@ -71,7 +71,13 @@ public sealed class AcquisitionDecisionPipeline(IMediaSearchPlanner mediaSearchP
 
     public AcquisitionSelectedReleaseDecision EvaluateSelectedRelease(AcquisitionSelectedReleaseRequest request)
     {
-        var quality = Deluno.Platform.Quality.LibraryQualityDecider.DetectQuality(request.ReleaseName) ?? "WEB 1080p";
+        var quality = request.CandidateQuality
+            ?? Deluno.Platform.Quality.LibraryQualityDecider.DetectQuality(request.ReleaseName)
+            ?? "WEB 1080p";
+        var customFormatScore = CustomFormatMatcher.Evaluate(
+            request.ReleaseName,
+            request.CustomFormats,
+            out var matchedCustomFormats);
         var decision = ReleaseDecisionEngine.Decide(new ReleaseDecisionInput(
             request.ReleaseName,
             quality,
@@ -80,8 +86,8 @@ public sealed class AcquisitionDecisionPipeline(IMediaSearchPlanner mediaSearchP
             request.SizeBytes,
             request.Seeders,
             request.DownloadUrl,
-            SourcePriorityScore: 0,
-            CustomFormatScore: 0,
+            SourcePriorityScore: request.SourcePriorityScore ?? 0,
+            CustomFormatScore: customFormatScore,
             request.NeverGrabPatterns));
 
         var candidate = new MediaSearchCandidate(
@@ -104,7 +110,8 @@ public sealed class AcquisitionDecisionPipeline(IMediaSearchPlanner mediaSearchP
             SizeScore: decision.SizeScore,
             ReleaseGroup: decision.ReleaseGroup,
             EstimatedBitrateMbps: decision.EstimatedBitrateMbps,
-            PolicyVersion: decision.PolicyVersion);
+            PolicyVersion: decision.PolicyVersion,
+            MatchedCustomFormats: matchedCustomFormats);
 
         var safe = IsSafeForAutomaticDispatch(candidate);
 
@@ -218,8 +225,11 @@ public sealed record AcquisitionSelectedReleaseRequest(
     string? DownloadUrl,
     string? CurrentQuality,
     string? TargetQuality,
+    string? CandidateQuality = null,
     long? SizeBytes = null,
     int? Seeders = null,
+    int? SourcePriorityScore = null,
+    IReadOnlyList<CustomFormatItem>? CustomFormats = null,
     bool ForceOverride = false,
     string? OverrideReason = null,
     IReadOnlyList<string>? NeverGrabPatterns = null,

--- a/src/Deluno.Integrations/Search/CustomFormatMatcher.cs
+++ b/src/Deluno.Integrations/Search/CustomFormatMatcher.cs
@@ -99,6 +99,7 @@ public static partial class CustomFormatMatcher
             results.Add(new CustomFormatDryRunResult(
                 FormatId: format.Id,
                 FormatName: format.Name,
+                MediaType: format.MediaType,
                 Score: format.Score,
                 IsMatch: isMatch,
                 MatchedConditions: matchedConditions,
@@ -312,6 +313,7 @@ public sealed record CustomFormatMatchResult(
 public sealed record CustomFormatDryRunResult(
     string FormatId,
     string FormatName,
+    string MediaType,
     int Score,
     bool IsMatch,
     IReadOnlyList<string> MatchedConditions,

--- a/src/Deluno.Integrations/Search/SearchEndpointRouteBuilderExtensions.cs
+++ b/src/Deluno.Integrations/Search/SearchEndpointRouteBuilderExtensions.cs
@@ -34,6 +34,13 @@ public static class SearchEndpointRouteBuilderExtensions
             }
 
             var formats = await repository.ListCustomFormatsAsync(cancellationToken);
+            if (!string.IsNullOrWhiteSpace(request.MediaType))
+            {
+                formats = formats
+                    .Where(format => string.Equals(format.MediaType, request.MediaType, StringComparison.OrdinalIgnoreCase))
+                    .ToArray();
+            }
+
             var results = CustomFormatMatcher.DryRun(request.ReleaseName, formats);
             return Results.Ok(results);
         });

--- a/src/Deluno.Jobs/Data/SqliteJobStore.cs
+++ b/src/Deluno.Jobs/Data/SqliteJobStore.cs
@@ -1243,6 +1243,7 @@ public sealed class SqliteJobStore(
     {
         var now = timeProvider.GetUtcNow();
         var dispatchId = Guid.CreateVersion7().ToString("N");
+        var decisionTelemetry = TryParseDispatchDecisionTelemetry(notesJson);
 
         await using var connection = await databaseConnectionFactory.OpenConnectionAsync(
             DelunoDatabaseNames.Jobs,
@@ -1257,11 +1258,21 @@ public sealed class SqliteJobStore(
                 """
                 INSERT INTO download_dispatches (
                     id, library_id, media_type, entity_type, entity_id, release_name,
-                    indexer_name, download_client_id, download_client_name, status, notes_json, created_utc
+                    indexer_name, download_client_id, download_client_name, status, notes_json,
+                    decision_quality, decision_score, decision_meets_cutoff, decision_status, decision_quality_delta,
+                    decision_custom_format_score, decision_seeder_score, decision_size_score, decision_release_group,
+                    decision_estimated_bitrate_mbps, decision_size_bytes, decision_seeders, decision_policy_version,
+                    decision_matched_custom_formats_json, decision_reasons_json, decision_risk_flags_json,
+                    decision_override_used, decision_override_reason, created_utc
                 )
                 VALUES (
                     @id, @libraryId, @mediaType, @entityType, @entityId, @releaseName,
-                    @indexerName, @downloadClientId, @downloadClientName, @status, @notesJson, @createdUtc
+                    @indexerName, @downloadClientId, @downloadClientName, @status, @notesJson,
+                    @decisionQuality, @decisionScore, @decisionMeetsCutoff, @decisionStatus, @decisionQualityDelta,
+                    @decisionCustomFormatScore, @decisionSeederScore, @decisionSizeScore, @decisionReleaseGroup,
+                    @decisionEstimatedBitrateMbps, @decisionSizeBytes, @decisionSeeders, @decisionPolicyVersion,
+                    @decisionMatchedCustomFormatsJson, @decisionReasonsJson, @decisionRiskFlagsJson,
+                    @decisionOverrideUsed, @decisionOverrideReason, @createdUtc
                 );
                 """;
 
@@ -1276,6 +1287,27 @@ public sealed class SqliteJobStore(
             AddParameter(command, "@downloadClientName", downloadClientName);
             AddParameter(command, "@status", status);
             AddParameter(command, "@notesJson", notesJson);
+            AddParameter(command, "@decisionQuality", decisionTelemetry?.Quality);
+            AddParameter(command, "@decisionScore", decisionTelemetry?.Score);
+            AddParameter(
+                command,
+                "@decisionMeetsCutoff",
+                decisionTelemetry?.MeetsCutoff is true ? 1 : decisionTelemetry?.MeetsCutoff is false ? 0 : null);
+            AddParameter(command, "@decisionStatus", decisionTelemetry?.DecisionStatus);
+            AddParameter(command, "@decisionQualityDelta", decisionTelemetry?.QualityDelta);
+            AddParameter(command, "@decisionCustomFormatScore", decisionTelemetry?.CustomFormatScore);
+            AddParameter(command, "@decisionSeederScore", decisionTelemetry?.SeederScore);
+            AddParameter(command, "@decisionSizeScore", decisionTelemetry?.SizeScore);
+            AddParameter(command, "@decisionReleaseGroup", decisionTelemetry?.ReleaseGroup);
+            AddParameter(command, "@decisionEstimatedBitrateMbps", decisionTelemetry?.EstimatedBitrateMbps);
+            AddParameter(command, "@decisionSizeBytes", decisionTelemetry?.SizeBytes);
+            AddParameter(command, "@decisionSeeders", decisionTelemetry?.Seeders);
+            AddParameter(command, "@decisionPolicyVersion", decisionTelemetry?.PolicyVersion);
+            AddParameter(command, "@decisionMatchedCustomFormatsJson", decisionTelemetry?.MatchedCustomFormatsJson);
+            AddParameter(command, "@decisionReasonsJson", decisionTelemetry?.ReasonsJson);
+            AddParameter(command, "@decisionRiskFlagsJson", decisionTelemetry?.RiskFlagsJson);
+            AddParameter(command, "@decisionOverrideUsed", decisionTelemetry is null ? 0 : decisionTelemetry.OverrideUsed ? 1 : 0);
+            AddParameter(command, "@decisionOverrideReason", decisionTelemetry?.OverrideReason);
             AddParameter(command, "@createdUtc", now.ToString("O"));
             await command.ExecuteNonQueryAsync(cancellationToken);
         }
@@ -2247,4 +2279,135 @@ public sealed class SqliteJobStore(
             "paused" => "paused",
             _ => status
         };
+
+    private static DispatchDecisionTelemetry? TryParseDispatchDecisionTelemetry(string? notesJson)
+    {
+        if (string.IsNullOrWhiteSpace(notesJson))
+        {
+            return null;
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(notesJson);
+            var root = document.RootElement;
+            var candidate = ResolveDecisionCandidate(root);
+            if (candidate is null)
+            {
+                return null;
+            }
+
+            return new DispatchDecisionTelemetry(
+                Quality: GetString(candidate.Value, "Quality"),
+                Score: GetInt32(candidate.Value, "Score"),
+                MeetsCutoff: GetBoolean(candidate.Value, "MeetsCutoff"),
+                DecisionStatus: GetString(candidate.Value, "DecisionStatus"),
+                QualityDelta: GetInt32(candidate.Value, "QualityDelta"),
+                CustomFormatScore: GetInt32(candidate.Value, "CustomFormatScore"),
+                SeederScore: GetInt32(candidate.Value, "SeederScore"),
+                SizeScore: GetInt32(candidate.Value, "SizeScore"),
+                ReleaseGroup: GetString(candidate.Value, "ReleaseGroup"),
+                EstimatedBitrateMbps: GetDouble(candidate.Value, "EstimatedBitrateMbps"),
+                SizeBytes: GetInt64(candidate.Value, "SizeBytes"),
+                Seeders: GetInt32(candidate.Value, "Seeders"),
+                PolicyVersion: GetString(candidate.Value, "PolicyVersion"),
+                MatchedCustomFormatsJson: GetRawJson(candidate.Value, "MatchedCustomFormats"),
+                ReasonsJson: GetRawJson(candidate.Value, "DecisionReasons"),
+                RiskFlagsJson: GetRawJson(candidate.Value, "RiskFlags"),
+                OverrideUsed: GetBoolean(root, "ForceOverride") ?? false,
+                OverrideReason: GetString(root, "OverrideReason"));
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static JsonElement? ResolveDecisionCandidate(JsonElement root)
+    {
+        if (TryGetPropertyIgnoreCase(root, "decision", out var decision) &&
+            TryGetPropertyIgnoreCase(decision, "candidate", out var decisionCandidate))
+        {
+            return decisionCandidate;
+        }
+
+        if (TryGetPropertyIgnoreCase(root, "searchPlan", out var searchPlan) &&
+            TryGetPropertyIgnoreCase(searchPlan, "bestCandidate", out var bestCandidate))
+        {
+            return bestCandidate;
+        }
+
+        if (TryGetPropertyIgnoreCase(root, "bestCandidate", out var rootBestCandidate))
+        {
+            return rootBestCandidate;
+        }
+
+        return null;
+    }
+
+    private static bool TryGetPropertyIgnoreCase(JsonElement element, string name, out JsonElement value)
+    {
+        if (element.ValueKind == JsonValueKind.Object)
+        {
+            foreach (var property in element.EnumerateObject())
+            {
+                if (string.Equals(property.Name, name, StringComparison.OrdinalIgnoreCase))
+                {
+                    value = property.Value;
+                    return true;
+                }
+            }
+        }
+
+        value = default;
+        return false;
+    }
+
+    private static string? GetString(JsonElement element, string name)
+        => TryGetPropertyIgnoreCase(element, name, out var value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+
+    private static int? GetInt32(JsonElement element, string name)
+        => TryGetPropertyIgnoreCase(element, name, out var value) && value.TryGetInt32(out var result)
+            ? result
+            : null;
+
+    private static long? GetInt64(JsonElement element, string name)
+        => TryGetPropertyIgnoreCase(element, name, out var value) && value.TryGetInt64(out var result)
+            ? result
+            : null;
+
+    private static double? GetDouble(JsonElement element, string name)
+        => TryGetPropertyIgnoreCase(element, name, out var value) && value.TryGetDouble(out var result)
+            ? result
+            : null;
+
+    private static bool? GetBoolean(JsonElement element, string name)
+        => TryGetPropertyIgnoreCase(element, name, out var value) && (value.ValueKind is JsonValueKind.True or JsonValueKind.False)
+            ? value.GetBoolean()
+            : null;
+
+    private static string? GetRawJson(JsonElement element, string name)
+        => TryGetPropertyIgnoreCase(element, name, out var value) ? value.GetRawText() : null;
+
+    private sealed record DispatchDecisionTelemetry(
+        string? Quality,
+        int? Score,
+        bool? MeetsCutoff,
+        string? DecisionStatus,
+        int? QualityDelta,
+        int? CustomFormatScore,
+        int? SeederScore,
+        int? SizeScore,
+        string? ReleaseGroup,
+        double? EstimatedBitrateMbps,
+        long? SizeBytes,
+        int? Seeders,
+        string? PolicyVersion,
+        string? MatchedCustomFormatsJson,
+        string? ReasonsJson,
+        string? RiskFlagsJson,
+        bool OverrideUsed,
+        string? OverrideReason);
 }

--- a/src/Deluno.Jobs/Migrations/V0001InitialSchema.cs
+++ b/src/Deluno.Jobs/Migrations/V0001InitialSchema.cs
@@ -13,7 +13,8 @@ public static class JobsDatabaseMigrations
         new V0005DispatchAlerts(),
         new V0006DownloadRetryTracking(),
         new V0007IntegrationCircuitState(),
-        new V0008DownloadRetryWindowTracking()
+        new V0008DownloadRetryWindowTracking(),
+        new V0009DecisionTelemetryTracking()
     ];
 
     private sealed class V0001InitialSchema : SqliteSqlMigration

--- a/src/Deluno.Jobs/Migrations/V0009DecisionTelemetryTracking.cs
+++ b/src/Deluno.Jobs/Migrations/V0009DecisionTelemetryTracking.cs
@@ -1,0 +1,36 @@
+using Deluno.Infrastructure.Storage.Migrations;
+
+namespace Deluno.Jobs.Migrations;
+
+public sealed class V0009DecisionTelemetryTracking : SqliteSqlMigration
+{
+    public override int Version => 9;
+
+    public override string Name => "decision_telemetry_tracking";
+
+    protected override string Sql =>
+        """
+        ALTER TABLE download_dispatches ADD COLUMN decision_quality TEXT NULL;
+        ALTER TABLE download_dispatches ADD COLUMN decision_score INTEGER NULL;
+        ALTER TABLE download_dispatches ADD COLUMN decision_meets_cutoff INTEGER NULL;
+        ALTER TABLE download_dispatches ADD COLUMN decision_status TEXT NULL;
+        ALTER TABLE download_dispatches ADD COLUMN decision_quality_delta INTEGER NULL;
+        ALTER TABLE download_dispatches ADD COLUMN decision_custom_format_score INTEGER NULL;
+        ALTER TABLE download_dispatches ADD COLUMN decision_seeder_score INTEGER NULL;
+        ALTER TABLE download_dispatches ADD COLUMN decision_size_score INTEGER NULL;
+        ALTER TABLE download_dispatches ADD COLUMN decision_release_group TEXT NULL;
+        ALTER TABLE download_dispatches ADD COLUMN decision_estimated_bitrate_mbps REAL NULL;
+        ALTER TABLE download_dispatches ADD COLUMN decision_size_bytes INTEGER NULL;
+        ALTER TABLE download_dispatches ADD COLUMN decision_seeders INTEGER NULL;
+        ALTER TABLE download_dispatches ADD COLUMN decision_policy_version TEXT NULL;
+        ALTER TABLE download_dispatches ADD COLUMN decision_matched_custom_formats_json TEXT NULL;
+        ALTER TABLE download_dispatches ADD COLUMN decision_reasons_json TEXT NULL;
+        ALTER TABLE download_dispatches ADD COLUMN decision_risk_flags_json TEXT NULL;
+        ALTER TABLE download_dispatches ADD COLUMN decision_override_used INTEGER NOT NULL DEFAULT 0;
+        ALTER TABLE download_dispatches ADD COLUMN decision_override_reason TEXT NULL;
+
+        CREATE INDEX IF NOT EXISTS ix_download_dispatches_decision_status
+            ON download_dispatches (decision_status, created_utc DESC)
+            WHERE decision_status IS NOT NULL;
+        """;
+}

--- a/src/Deluno.Movies/MoviesEndpointRouteBuilderExtensions.cs
+++ b/src/Deluno.Movies/MoviesEndpointRouteBuilderExtensions.cs
@@ -522,14 +522,24 @@ public static class MoviesEndpointRouteBuilderExtensions
             var overrideReason = string.IsNullOrWhiteSpace(request.OverrideReason)
                 ? "User manually forced this release from search results."
                 : request.OverrideReason.Trim();
+            var customFormats = await ResolveCustomFormatsAsync(platformSettingsRepository, library.QualityProfileId, cancellationToken);
+            var sourcePriorityScore = routing?.Sources
+                .FirstOrDefault(item => string.Equals(item.IndexerId, request.IndexerId, StringComparison.OrdinalIgnoreCase)) is { } source
+                    ? Math.Max(0, 200 - source.Priority)
+                    : 0;
             var selectedDecision = acquisitionPipeline.EvaluateSelectedRelease(
                 new AcquisitionSelectedReleaseRequest(
                     request.ReleaseName.Trim(),
-                    null,
+                    request.IndexerId?.Trim(),
                     request.IndexerName?.Trim(),
                     request.DownloadUrl!.Trim(),
                     wantedItem.CurrentQuality,
                     wantedItem.TargetQuality,
+                    request.CandidateQuality?.Trim(),
+                    request.SizeBytes,
+                    request.Seeders,
+                    sourcePriorityScore,
+                    customFormats,
                     ForceOverride: forceOverride,
                     OverrideReason: forceOverride ? overrideReason : null,
                     PreventLowerQualityReplacements: wantedItem.PreventLowerQualityReplacements));
@@ -1234,8 +1244,12 @@ public static class MoviesEndpointRouteBuilderExtensions
 
     private sealed record ReleaseGrabRequest(
         string ReleaseName,
+        string? IndexerId,
         string? IndexerName,
         string? DownloadUrl,
+        string? CandidateQuality,
+        long? SizeBytes,
+        int? Seeders,
         bool? Force,
         string? OverrideReason);
 

--- a/src/Deluno.Platform/Contracts/CreateCustomFormatRequest.cs
+++ b/src/Deluno.Platform/Contracts/CreateCustomFormatRequest.cs
@@ -4,5 +4,6 @@ public sealed record CreateCustomFormatRequest(
     string Name,
     string? MediaType,
     int Score,
+    string? TrashId,
     string? Conditions,
     bool UpgradeAllowed);

--- a/src/Deluno.Platform/Contracts/CustomFormatDryRunRequest.cs
+++ b/src/Deluno.Platform/Contracts/CustomFormatDryRunRequest.cs
@@ -1,3 +1,3 @@
 namespace Deluno.Platform.Contracts;
 
-public sealed record CustomFormatDryRunRequest(string ReleaseName);
+public sealed record CustomFormatDryRunRequest(string ReleaseName, string? MediaType = null);

--- a/src/Deluno.Platform/Contracts/CustomFormatItem.cs
+++ b/src/Deluno.Platform/Contracts/CustomFormatItem.cs
@@ -5,6 +5,7 @@ public sealed record CustomFormatItem(
     string Name,
     string MediaType,
     int Score,
+    string? TrashId,
     string Conditions,
     bool UpgradeAllowed,
     DateTimeOffset CreatedUtc,

--- a/src/Deluno.Platform/Contracts/UpdateCustomFormatRequest.cs
+++ b/src/Deluno.Platform/Contracts/UpdateCustomFormatRequest.cs
@@ -4,5 +4,6 @@ public sealed record UpdateCustomFormatRequest(
     string Name,
     string? MediaType,
     int Score,
+    string? TrashId,
     string? Conditions,
     bool UpgradeAllowed);

--- a/src/Deluno.Platform/Data/SqlitePlatformSettingsRepository.cs
+++ b/src/Deluno.Platform/Data/SqlitePlatformSettingsRepository.cs
@@ -286,7 +286,7 @@ public sealed class SqlitePlatformSettingsRepository(
         command.CommandText =
             """
             SELECT
-                id, name, media_type, score, conditions, upgrade_allowed, created_utc, updated_utc
+                id, name, media_type, score, trash_id, conditions, upgrade_allowed, created_utc, updated_utc
             FROM custom_formats
             ORDER BY media_type ASC, score DESC, name COLLATE NOCASE ASC;
             """;
@@ -939,6 +939,7 @@ public sealed class SqlitePlatformSettingsRepository(
             Name: NormalizeName(request.Name) ?? "New custom format",
             MediaType: NormalizeMediaType(request.MediaType),
             Score: request.Score,
+            TrashId: NormalizeName(request.TrashId),
             Conditions: NormalizeName(request.Conditions) ?? string.Empty,
             UpgradeAllowed: request.UpgradeAllowed,
             CreatedUtc: now,
@@ -952,10 +953,10 @@ public sealed class SqlitePlatformSettingsRepository(
         command.CommandText =
             """
             INSERT INTO custom_formats (
-                id, name, media_type, score, conditions, upgrade_allowed, created_utc, updated_utc
+                id, name, media_type, score, trash_id, conditions, upgrade_allowed, created_utc, updated_utc
             )
             VALUES (
-                @id, @name, @mediaType, @score, @conditions, @upgradeAllowed, @createdUtc, @updatedUtc
+                @id, @name, @mediaType, @score, @trashId, @conditions, @upgradeAllowed, @createdUtc, @updatedUtc
             );
             """;
 
@@ -963,6 +964,7 @@ public sealed class SqlitePlatformSettingsRepository(
         AddParameter(command, "@name", item.Name);
         AddParameter(command, "@mediaType", item.MediaType);
         AddParameter(command, "@score", item.Score);
+        AddParameter(command, "@trashId", item.TrashId);
         AddParameter(command, "@conditions", item.Conditions);
         AddParameter(command, "@upgradeAllowed", item.UpgradeAllowed ? 1 : 0);
         AddParameter(command, "@createdUtc", item.CreatedUtc.ToString("O"));
@@ -1305,6 +1307,7 @@ public sealed class SqlitePlatformSettingsRepository(
                 name = @name,
                 media_type = @mediaType,
                 score = @score,
+                trash_id = @trashId,
                 conditions = @conditions,
                 upgrade_allowed = @upgradeAllowed,
                 updated_utc = @updatedUtc
@@ -1315,6 +1318,7 @@ public sealed class SqlitePlatformSettingsRepository(
         AddParameter(command, "@name", NormalizeName(request.Name) ?? current.Name);
         AddParameter(command, "@mediaType", NormalizeMediaType(request.MediaType ?? current.MediaType));
         AddParameter(command, "@score", request.Score);
+        AddParameter(command, "@trashId", NormalizeName(request.TrashId) ?? current.TrashId);
         AddParameter(command, "@conditions", NormalizeName(request.Conditions) ?? string.Empty);
         AddParameter(command, "@upgradeAllowed", request.UpgradeAllowed ? 1 : 0);
         AddParameter(command, "@updatedUtc", now.ToString("O"));
@@ -3198,7 +3202,7 @@ public sealed class SqlitePlatformSettingsRepository(
         command.CommandText =
             """
             SELECT
-                id, name, media_type, score, conditions, upgrade_allowed, created_utc, updated_utc
+                id, name, media_type, score, trash_id, conditions, upgrade_allowed, created_utc, updated_utc
             FROM custom_formats
             WHERE id = @id
             LIMIT 1;
@@ -3793,10 +3797,11 @@ public sealed class SqlitePlatformSettingsRepository(
             Name: reader.GetString(1),
             MediaType: reader.GetString(2),
             Score: reader.GetInt32(3),
-            Conditions: reader.GetString(4),
-            UpgradeAllowed: reader.GetInt64(5) == 1,
-            CreatedUtc: ParseTimestamp(reader.GetString(6)),
-            UpdatedUtc: ParseTimestamp(reader.GetString(7)));
+            TrashId: reader.IsDBNull(4) ? null : reader.GetString(4),
+            Conditions: reader.GetString(5),
+            UpgradeAllowed: reader.GetInt64(6) == 1,
+            CreatedUtc: ParseTimestamp(reader.GetString(7)),
+            UpdatedUtc: ParseTimestamp(reader.GetString(8)));
     }
 
     private static DestinationRuleItem ReadDestinationRule(System.Data.Common.DbDataReader reader)

--- a/src/Deluno.Platform/Migrations/V0001InitialSchema.cs
+++ b/src/Deluno.Platform/Migrations/V0001InitialSchema.cs
@@ -13,7 +13,8 @@ public static class PlatformDatabaseMigrations
         new V0005QualityProfilePresetTracking(),
         new V0006IndexerRateLimitTracking(),
         new V0007LibrarySearchWindows(),
-        new V0008NotificationWebhooks()
+        new V0008NotificationWebhooks(),
+        new V0009CustomFormatTrashIds()
     ];
 
     private sealed class V0001InitialSchema : SqliteSqlMigration

--- a/src/Deluno.Platform/Migrations/V0009CustomFormatTrashIds.cs
+++ b/src/Deluno.Platform/Migrations/V0009CustomFormatTrashIds.cs
@@ -1,0 +1,19 @@
+using Deluno.Infrastructure.Storage.Migrations;
+
+namespace Deluno.Platform.Migrations;
+
+public sealed class V0009CustomFormatTrashIds : SqliteSqlMigration
+{
+    public override int Version => 9;
+
+    public override string Name => "custom_format_trash_ids";
+
+    protected override string Sql =>
+        """
+        ALTER TABLE custom_formats ADD COLUMN trash_id TEXT NULL;
+
+        CREATE INDEX IF NOT EXISTS ix_custom_formats_media_trash
+            ON custom_formats (media_type, trash_id)
+            WHERE trash_id IS NOT NULL;
+        """;
+}

--- a/src/Deluno.Series/Contracts/SeriesUpcomingEpisodeItem.cs
+++ b/src/Deluno.Series/Contracts/SeriesUpcomingEpisodeItem.cs
@@ -1,0 +1,12 @@
+namespace Deluno.Series.Contracts;
+
+public sealed record SeriesUpcomingEpisodeItem(
+    string SeriesId,
+    string Title,
+    int? StartYear,
+    string? PosterUrl,
+    string EpisodeId,
+    int SeasonNumber,
+    int EpisodeNumber,
+    string? EpisodeTitle,
+    DateTimeOffset AirDateUtc);

--- a/src/Deluno.Series/Data/ISeriesCatalogRepository.cs
+++ b/src/Deluno.Series/Data/ISeriesCatalogRepository.cs
@@ -35,6 +35,12 @@ public interface ISeriesCatalogRepository
 
     Task<SeriesInventoryDetail?> GetInventoryDetailAsync(string seriesId, CancellationToken cancellationToken);
 
+    Task<IReadOnlyList<SeriesUpcomingEpisodeItem>> ListUpcomingEpisodesAsync(
+        DateTimeOffset fromUtc,
+        DateTimeOffset toUtc,
+        int take,
+        CancellationToken cancellationToken);
+
     Task<IReadOnlyList<SeriesSearchHistoryItem>> ListSearchHistoryAsync(CancellationToken cancellationToken);
 
     Task<IReadOnlyList<SeriesWantedItem>> ListEligibleWantedAsync(

--- a/src/Deluno.Series/Data/SqliteSeriesCatalogRepository.cs
+++ b/src/Deluno.Series/Data/SqliteSeriesCatalogRepository.cs
@@ -581,6 +581,61 @@ public sealed class SqliteSeriesCatalogRepository(
             Episodes: episodes);
     }
 
+    public async Task<IReadOnlyList<SeriesUpcomingEpisodeItem>> ListUpcomingEpisodesAsync(
+        DateTimeOffset fromUtc,
+        DateTimeOffset toUtc,
+        int take,
+        CancellationToken cancellationToken)
+    {
+        await using var connection = await databaseConnectionFactory.OpenConnectionAsync(
+            DelunoDatabaseNames.Series,
+            cancellationToken);
+
+        var items = new List<SeriesUpcomingEpisodeItem>();
+        using var command = connection.CreateCommand();
+        command.CommandText =
+            """
+            SELECT
+                s.id,
+                s.title,
+                s.start_year,
+                s.poster_url,
+                e.id,
+                e.season_number,
+                e.episode_number,
+                e.title,
+                e.air_date_utc
+            FROM episode_entries e
+            INNER JOIN series_entries s ON s.id = e.series_id
+            WHERE e.air_date_utc IS NOT NULL
+              AND e.monitored = 1
+              AND e.air_date_utc >= @fromUtc
+              AND e.air_date_utc <= @toUtc
+            ORDER BY e.air_date_utc ASC, s.title COLLATE NOCASE ASC, e.season_number ASC, e.episode_number ASC
+            LIMIT @take;
+            """;
+        AddParameter(command, "@fromUtc", fromUtc.ToString("O"));
+        AddParameter(command, "@toUtc", toUtc.ToString("O"));
+        AddParameter(command, "@take", take);
+
+        using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            items.Add(new SeriesUpcomingEpisodeItem(
+                SeriesId: reader.GetString(0),
+                Title: reader.GetString(1),
+                StartYear: reader.IsDBNull(2) ? null : reader.GetInt32(2),
+                PosterUrl: reader.IsDBNull(3) ? null : reader.GetString(3),
+                EpisodeId: reader.GetString(4),
+                SeasonNumber: reader.GetInt32(5),
+                EpisodeNumber: reader.GetInt32(6),
+                EpisodeTitle: reader.IsDBNull(7) ? null : reader.GetString(7),
+                AirDateUtc: ParseTimestamp(reader.GetString(8))));
+        }
+
+        return items;
+    }
+
     public async Task<IReadOnlyList<SeriesSearchHistoryItem>> ListSearchHistoryAsync(CancellationToken cancellationToken)
     {
         var items = new List<SeriesSearchHistoryItem>();

--- a/src/Deluno.Series/SeriesEndpointRouteBuilderExtensions.cs
+++ b/src/Deluno.Series/SeriesEndpointRouteBuilderExtensions.cs
@@ -58,6 +58,23 @@ public static class SeriesEndpointRouteBuilderExtensions
             return detail is null ? Results.NotFound() : Results.Ok(detail);
         });
 
+        series.MapGet("/upcoming", async (
+            int? take,
+            int? hours,
+            ISeriesCatalogRepository repository,
+            CancellationToken cancellationToken) =>
+        {
+            var now = DateTimeOffset.UtcNow;
+            var requestedTake = take is > 0 and <= 100 ? take.Value : 12;
+            var requestedHours = hours is > 0 and <= 336 ? hours.Value : 72;
+            var items = await repository.ListUpcomingEpisodesAsync(
+                now,
+                now.AddHours(requestedHours),
+                requestedTake,
+                cancellationToken);
+            return Results.Ok(items);
+        });
+
         series.MapGet("/search-history", async (ISeriesCatalogRepository repository, CancellationToken cancellationToken) =>
         {
             var items = await repository.ListSearchHistoryAsync(cancellationToken);
@@ -1003,14 +1020,24 @@ public static class SeriesEndpointRouteBuilderExtensions
             var overrideReason = string.IsNullOrWhiteSpace(request.OverrideReason)
                 ? "User manually forced this release from search results."
                 : request.OverrideReason.Trim();
+            var customFormats = await ResolveCustomFormatsAsync(platformSettingsRepository, library.QualityProfileId, cancellationToken);
+            var sourcePriorityScore = routing?.Sources
+                .FirstOrDefault(item => string.Equals(item.IndexerId, request.IndexerId, StringComparison.OrdinalIgnoreCase)) is { } source
+                    ? Math.Max(0, 200 - source.Priority)
+                    : 0;
             var selectedDecision = acquisitionPipeline.EvaluateSelectedRelease(
                 new AcquisitionSelectedReleaseRequest(
                     request.ReleaseName.Trim(),
-                    null,
+                    request.IndexerId?.Trim(),
                     request.IndexerName?.Trim(),
                     request.DownloadUrl!.Trim(),
                     wantedItem.CurrentQuality,
                     wantedItem.TargetQuality,
+                    request.CandidateQuality?.Trim(),
+                    request.SizeBytes,
+                    request.Seeders,
+                    sourcePriorityScore,
+                    customFormats,
                     ForceOverride: forceOverride,
                     OverrideReason: forceOverride ? overrideReason : null,
                     PreventLowerQualityReplacements: wantedItem.PreventLowerQualityReplacements));
@@ -1683,8 +1710,12 @@ public static class SeriesEndpointRouteBuilderExtensions
 
     private sealed record ReleaseGrabRequest(
         string ReleaseName,
+        string? IndexerId,
         string? IndexerName,
         string? DownloadUrl,
+        string? CandidateQuality,
+        long? SizeBytes,
+        int? Seeders,
         bool? Force,
         string? OverrideReason);
 

--- a/tests/Deluno.Integrations.Tests/Search/AcquisitionDecisionPipelineTests.cs
+++ b/tests/Deluno.Integrations.Tests/Search/AcquisitionDecisionPipelineTests.cs
@@ -1,5 +1,6 @@
 using Deluno.Integrations.Search;
 using Moq;
+using Deluno.Platform.Contracts;
 
 namespace Deluno.Integrations.Tests.Search;
 
@@ -222,5 +223,37 @@ public class AcquisitionDecisionPipelineTests
 
         Assert.Equal("idx-42", result.Candidate.IndexerId);
         Assert.Equal("My Indexer", result.Candidate.IndexerName);
+    }
+
+    [Fact]
+    public void EvaluateSelectedRelease_uses_source_priority_and_custom_formats_from_manual_context()
+    {
+        var customFormats = new[]
+        {
+            new CustomFormatItem(
+                Id: "cf-1",
+                Name: "Preferred Group",
+                MediaType: "movies",
+                Score: 125,
+                TrashId: "trash-group",
+                Conditions: """[{"type":"releaseGroup","value":"GROUP","required":true}]""",
+                UpgradeAllowed: true,
+                CreatedUtc: DateTimeOffset.UtcNow,
+                UpdatedUtc: DateTimeOffset.UtcNow)
+        };
+
+        var baseline = _pipeline.EvaluateSelectedRelease(BuildRequest());
+        var enriched = _pipeline.EvaluateSelectedRelease(BuildRequest() with
+        {
+            IndexerId = "idx-1",
+            IndexerName = "Primary",
+            CandidateQuality = "WEB 1080p",
+            SourcePriorityScore = 175,
+            CustomFormats = customFormats
+        });
+
+        Assert.True(enriched.Candidate.Score > baseline.Candidate.Score);
+        Assert.Equal(125, enriched.Candidate.CustomFormatScore);
+        Assert.NotEmpty(enriched.Candidate.MatchedCustomFormats ?? []);
     }
 }

--- a/tests/Deluno.Persistence.Tests/Integrations/CustomFormatMatcherTests.cs
+++ b/tests/Deluno.Persistence.Tests/Integrations/CustomFormatMatcherTests.cs
@@ -6,7 +6,7 @@ namespace Deluno.Persistence.Tests.Integrations;
 public sealed class CustomFormatMatcherTests
 {
     private static CustomFormatItem Format(string id, string name, int score, string? conditions)
-        => new(id, name, "movies", score, conditions ?? string.Empty, false,
+        => new(id, name, "movies", score, null, conditions ?? string.Empty, false,
             DateTimeOffset.UnixEpoch, DateTimeOffset.UnixEpoch);
 
     // ── No formats / empty ────────────────────────────────────────────────

--- a/tests/Deluno.Persistence.Tests/Jobs/JobStoreTests.cs
+++ b/tests/Deluno.Persistence.Tests/Jobs/JobStoreTests.cs
@@ -1,5 +1,6 @@
 using Deluno.Jobs.Contracts;
 using Deluno.Jobs.Data;
+using Deluno.Infrastructure.Storage;
 using Deluno.Persistence.Tests.Support;
 using Deluno.Infrastructure.Storage.Migrations;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -167,6 +168,91 @@ public sealed class JobStoreTests
         Assert.NotNull(retryLease);
         Assert.Equal(queued.Id, retryLease.Id);
         Assert.Equal(2, retryLease.Attempts);
+    }
+
+    [Fact]
+    public async Task RecordDownloadDispatchAsync_extracts_structured_decision_telemetry_from_notes_json()
+    {
+        using var storage = TestStorage.Create();
+        var timeProvider = new FixedTimeProvider(DateTimeOffset.Parse("2026-05-13T05:00:00Z"));
+        await InitializeJobsAsync(storage, timeProvider);
+        var store = new SqliteJobStore(storage.Factory, timeProvider, new NullRealtimeEventPublisher(), new NullDownloadDispatchesRepository());
+
+        var dispatchId = await store.RecordDownloadDispatchAsync(
+            libraryId: "movies-main",
+            mediaType: "movies",
+            entityType: "movie",
+            entityId: "movie-1",
+            releaseName: "Movie.2026.1080p.WEB-DL-GROUP",
+            indexerName: "Indexer One",
+            downloadClientId: "qb-1",
+            downloadClientName: "qBittorrent",
+            status: "sent",
+            notesJson:
+                """
+                {
+                  "searchPlan": {
+                    "bestCandidate": {
+                      "releaseName": "Movie.2026.1080p.WEB-DL-GROUP",
+                      "quality": "WEB 1080p",
+                      "score": 410,
+                      "meetsCutoff": true,
+                      "decisionStatus": "preferred",
+                      "qualityDelta": 1,
+                      "customFormatScore": 125,
+                      "seederScore": 120,
+                      "sizeScore": 80,
+                      "releaseGroup": "GROUP",
+                      "estimatedBitrateMbps": 8.4,
+                      "sizeBytes": 8000000000,
+                      "seeders": 20,
+                      "policyVersion": "policy-v1",
+                      "matchedCustomFormats": [{ "formatId": "cf-1", "formatName": "Preferred Group", "score": 125 }],
+                      "decisionReasons": ["Matched preferred group"],
+                      "riskFlags": []
+                    }
+                  }
+                }
+                """,
+            cancellationToken: CancellationToken.None);
+
+        await using var connection = await storage.Factory.OpenConnectionAsync(
+            DelunoDatabaseNames.Jobs,
+            CancellationToken.None);
+
+        using var command = connection.CreateCommand();
+        command.CommandText =
+            """
+            SELECT
+                decision_quality,
+                decision_score,
+                decision_meets_cutoff,
+                decision_status,
+                decision_custom_format_score,
+                decision_release_group,
+                decision_size_bytes,
+                decision_seeders,
+                decision_policy_version
+            FROM download_dispatches
+            WHERE id = @id
+            LIMIT 1;
+            """;
+        var idParameter = command.CreateParameter();
+        idParameter.ParameterName = "@id";
+        idParameter.Value = dispatchId;
+        command.Parameters.Add(idParameter);
+
+        using var reader = await command.ExecuteReaderAsync(CancellationToken.None);
+        Assert.True(await reader.ReadAsync(CancellationToken.None));
+        Assert.Equal("WEB 1080p", reader.GetString(0));
+        Assert.Equal(410, reader.GetInt32(1));
+        Assert.Equal(1L, reader.GetInt64(2));
+        Assert.Equal("preferred", reader.GetString(3));
+        Assert.Equal(125, reader.GetInt32(4));
+        Assert.Equal("GROUP", reader.GetString(5));
+        Assert.Equal(8000000000L, reader.GetInt64(6));
+        Assert.Equal(20, reader.GetInt32(7));
+        Assert.Equal("policy-v1", reader.GetString(8));
     }
 
     private static async Task InitializeJobsAsync(TestStorage storage, TimeProvider timeProvider)

--- a/tests/Deluno.Persistence.Tests/Migrations/MigrationRunnerTests.cs
+++ b/tests/Deluno.Persistence.Tests/Migrations/MigrationRunnerTests.cs
@@ -114,7 +114,7 @@ public sealed class MigrationRunnerTests
         Assert.Equal("series_import_recovery_status", await ReadScalarAsync<string>(seriesConnection, "SELECT name FROM schema_migrations WHERE version = 5;"));
 
         await using var platformConnection = await storage.Factory.OpenConnectionAsync(DelunoDatabaseNames.Platform);
-        Assert.Equal(8, await ReadScalarAsync<int>(platformConnection, "SELECT COUNT(*) FROM schema_migrations;"));
+        Assert.Equal(9, await ReadScalarAsync<int>(platformConnection, "SELECT COUNT(*) FROM schema_migrations;"));
         Assert.Equal("initial_schema", await ReadScalarAsync<string>(platformConnection, "SELECT name FROM schema_migrations WHERE version = 1;"));
         Assert.Equal("user_security_stamp", await ReadScalarAsync<string>(platformConnection, "SELECT name FROM schema_migrations WHERE version = 2;"));
         Assert.Equal("integration_health", await ReadScalarAsync<string>(platformConnection, "SELECT name FROM schema_migrations WHERE version = 3;"));
@@ -123,9 +123,10 @@ public sealed class MigrationRunnerTests
         Assert.Equal("indexer_rate_limit_tracking", await ReadScalarAsync<string>(platformConnection, "SELECT name FROM schema_migrations WHERE version = 6;"));
         Assert.Equal("library_search_windows", await ReadScalarAsync<string>(platformConnection, "SELECT name FROM schema_migrations WHERE version = 7;"));
         Assert.Equal("notification_webhooks", await ReadScalarAsync<string>(platformConnection, "SELECT name FROM schema_migrations WHERE version = 8;"));
+        Assert.Equal("custom_format_trash_ids", await ReadScalarAsync<string>(platformConnection, "SELECT name FROM schema_migrations WHERE version = 9;"));
 
         await using var jobsConnection = await storage.Factory.OpenConnectionAsync(DelunoDatabaseNames.Jobs);
-        Assert.Equal(8, await ReadScalarAsync<int>(jobsConnection, "SELECT COUNT(*) FROM schema_migrations;"));
+        Assert.Equal(9, await ReadScalarAsync<int>(jobsConnection, "SELECT COUNT(*) FROM schema_migrations;"));
         Assert.Equal("initial_schema", await ReadScalarAsync<string>(jobsConnection, "SELECT name FROM schema_migrations WHERE version = 1;"));
         Assert.Equal("job_integrity", await ReadScalarAsync<string>(jobsConnection, "SELECT name FROM schema_migrations WHERE version = 2;"));
         Assert.Equal("download_outcome_tracking", await ReadScalarAsync<string>(jobsConnection, "SELECT name FROM schema_migrations WHERE version = 3;"));
@@ -134,6 +135,7 @@ public sealed class MigrationRunnerTests
         Assert.Equal("download_retry_tracking", await ReadScalarAsync<string>(jobsConnection, "SELECT name FROM schema_migrations WHERE version = 6;"));
         Assert.Equal("integration_circuit_state", await ReadScalarAsync<string>(jobsConnection, "SELECT name FROM schema_migrations WHERE version = 7;"));
         Assert.Equal("download_retry_window_tracking", await ReadScalarAsync<string>(jobsConnection, "SELECT name FROM schema_migrations WHERE version = 8;"));
+        Assert.Equal("decision_telemetry_tracking", await ReadScalarAsync<string>(jobsConnection, "SELECT name FROM schema_migrations WHERE version = 9;"));
     }
 
     private static async Task<T> ReadScalarAsync<T>(DbConnection connection, string sql)

--- a/tests/Deluno.Persistence.Tests/Platform/CustomFormatPersistenceTests.cs
+++ b/tests/Deluno.Persistence.Tests/Platform/CustomFormatPersistenceTests.cs
@@ -1,0 +1,57 @@
+using Deluno.Infrastructure.Storage.Migrations;
+using Deluno.Persistence.Tests.Support;
+using Deluno.Platform.Contracts;
+using Deluno.Platform.Data;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Deluno.Persistence.Tests.Platform;
+
+public sealed class CustomFormatPersistenceTests
+{
+    [Fact]
+    public async Task CreateCustomFormatAsync_persists_media_type_and_trash_id_for_movies_and_tv()
+    {
+        using var storage = TestStorage.Create();
+        var timeProvider = new FixedTimeProvider(DateTimeOffset.Parse("2026-05-13T05:00:00Z"));
+
+        await new PlatformSchemaInitializer(
+            storage.Factory,
+            new SqliteDatabaseMigrator(storage.Factory, timeProvider),
+            NullLogger<PlatformSchemaInitializer>.Instance).StartAsync(CancellationToken.None);
+
+        var repository = new SqlitePlatformSettingsRepository(
+            storage.Factory,
+            timeProvider,
+            TestSecretProtection.Create(storage));
+
+        var movieFormat = await repository.CreateCustomFormatAsync(
+            new CreateCustomFormatRequest(
+                Name: "Movie HDR",
+                MediaType: "movies",
+                Score: 150,
+                TrashId: "trash-hdr",
+                Conditions: """[{"type":"hdr","value":"hdr10"}]""",
+                UpgradeAllowed: true),
+            CancellationToken.None);
+
+        var tvFormat = await repository.CreateCustomFormatAsync(
+            new CreateCustomFormatRequest(
+                Name: "TV HDR",
+                MediaType: "tv",
+                Score: 120,
+                TrashId: "trash-hdr",
+                Conditions: """[{"type":"hdr","value":"hdr10"}]""",
+                UpgradeAllowed: true),
+            CancellationToken.None);
+
+        var formats = await repository.ListCustomFormatsAsync(CancellationToken.None);
+
+        var storedMovie = Assert.Single(formats.Where(item => item.Id == movieFormat.Id));
+        var storedTv = Assert.Single(formats.Where(item => item.Id == tvFormat.Id));
+
+        Assert.Equal("movies", storedMovie.MediaType);
+        Assert.Equal("trash-hdr", storedMovie.TrashId);
+        Assert.Equal("tv", storedTv.MediaType);
+        Assert.Equal("trash-hdr", storedTv.TrashId);
+    }
+}

--- a/tests/Deluno.Persistence.Tests/Series/SeriesUpcomingEpisodePersistenceTests.cs
+++ b/tests/Deluno.Persistence.Tests/Series/SeriesUpcomingEpisodePersistenceTests.cs
@@ -1,0 +1,103 @@
+using Deluno.Infrastructure.Storage;
+using Deluno.Infrastructure.Storage.Migrations;
+using Deluno.Persistence.Tests.Support;
+using Deluno.Series.Contracts;
+using Deluno.Series.Data;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Deluno.Persistence.Tests.Series;
+
+public sealed class SeriesUpcomingEpisodePersistenceTests
+{
+    [Fact]
+    public async Task ListUpcomingEpisodesAsync_returns_monitored_episodes_within_requested_window()
+    {
+        using var storage = TestStorage.Create();
+        var timeProvider = new FixedTimeProvider(DateTimeOffset.Parse("2026-05-13T05:00:00Z"));
+
+        await new SeriesSchemaInitializer(
+            storage.Factory,
+            new SqliteDatabaseMigrator(storage.Factory, timeProvider),
+            NullLogger<SeriesSchemaInitializer>.Instance).StartAsync(CancellationToken.None);
+
+        var repository = new SqliteSeriesCatalogRepository(storage.Factory, timeProvider);
+        var series = await repository.AddAsync(
+            new CreateSeriesRequest("Severance", 2022, "tt11280740"),
+            CancellationToken.None);
+
+        await using var connection = await storage.Factory.OpenConnectionAsync(
+            DelunoDatabaseNames.Series,
+            CancellationToken.None);
+
+        var seasonId = Guid.CreateVersion7().ToString("N");
+        using (var seasonCommand = connection.CreateCommand())
+        {
+            seasonCommand.CommandText =
+                """
+                INSERT INTO season_entries (id, series_id, season_number, monitored, created_utc, updated_utc)
+                VALUES (@id, @seriesId, 1, 1, @createdUtc, @updatedUtc);
+                """;
+            AddParameter(seasonCommand, "@id", seasonId);
+            AddParameter(seasonCommand, "@seriesId", series.Id);
+            AddParameter(seasonCommand, "@createdUtc", timeProvider.GetUtcNow().ToString("O"));
+            AddParameter(seasonCommand, "@updatedUtc", timeProvider.GetUtcNow().ToString("O"));
+            await seasonCommand.ExecuteNonQueryAsync(CancellationToken.None);
+        }
+
+        await InsertEpisodeAsync(connection, series.Id, seasonId, 1, 1, "Hello, Ms. Cobel", timeProvider.GetUtcNow().AddHours(24));
+        await InsertEpisodeAsync(connection, series.Id, seasonId, 1, 2, "Out of window", timeProvider.GetUtcNow().AddHours(120));
+
+        var upcoming = await repository.ListUpcomingEpisodesAsync(
+            timeProvider.GetUtcNow(),
+            timeProvider.GetUtcNow().AddHours(72),
+            10,
+            CancellationToken.None);
+
+        var item = Assert.Single(upcoming);
+        Assert.Equal(series.Id, item.SeriesId);
+        Assert.Equal("Severance", item.Title);
+        Assert.Equal(1, item.SeasonNumber);
+        Assert.Equal(1, item.EpisodeNumber);
+        Assert.Equal("Hello, Ms. Cobel", item.EpisodeTitle);
+    }
+
+    private static async Task InsertEpisodeAsync(
+        System.Data.Common.DbConnection connection,
+        string seriesId,
+        string seasonId,
+        int seasonNumber,
+        int episodeNumber,
+        string title,
+        DateTimeOffset airDateUtc)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText =
+            """
+            INSERT INTO episode_entries (
+                id, series_id, season_id, season_number, episode_number, title, air_date_utc,
+                monitored, has_file, quality_cutoff_met, created_utc, updated_utc
+            ) VALUES (
+                @id, @seriesId, @seasonId, @seasonNumber, @episodeNumber, @title, @airDateUtc,
+                1, 0, 0, @createdUtc, @updatedUtc
+            );
+            """;
+        AddParameter(command, "@id", Guid.CreateVersion7().ToString("N"));
+        AddParameter(command, "@seriesId", seriesId);
+        AddParameter(command, "@seasonId", seasonId);
+        AddParameter(command, "@seasonNumber", seasonNumber);
+        AddParameter(command, "@episodeNumber", episodeNumber);
+        AddParameter(command, "@title", title);
+        AddParameter(command, "@airDateUtc", airDateUtc.ToString("O"));
+        AddParameter(command, "@createdUtc", airDateUtc.ToString("O"));
+        AddParameter(command, "@updatedUtc", airDateUtc.ToString("O"));
+        await command.ExecuteNonQueryAsync(CancellationToken.None);
+    }
+
+    private static void AddParameter(System.Data.Common.DbCommand command, string name, object? value)
+    {
+        var parameter = command.CreateParameter();
+        parameter.ParameterName = name;
+        parameter.Value = value ?? DBNull.Value;
+        command.Parameters.Add(parameter);
+    }
+}


### PR DESCRIPTION
## Summary
- fix custom format library handling so TV and movie formats can share TRaSH ids without colliding
- replace dashboard upcoming-series N+1 loading with a single aggregated upcoming episodes endpoint
- align manual grab evaluation with the automatic scoring pipeline inputs and custom format scoring
- persist structured decision telemetry for dispatches to support analytics and future learning
- harden migration coverage and Playwright smoke data isolation for stable validation

## Closes
Fixes #58
Fixes #59
Fixes #60
Fixes #61